### PR TITLE
generate JSON respecting data type

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -748,8 +748,8 @@ public abstract class Model extends CallbackSupport implements Externalizable {
 
     private static DateFormat isoDateFormater;
     static {
-    	isoDateFormater = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
-    	isoDateFormater.setTimeZone(TimeZone.getTimeZone("UTC"));
+        isoDateFormater = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'");
+        isoDateFormater.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
     protected  String toJsonP(boolean pretty, String indent, String... attrs) {
         Collection<String> attrList = Arrays.asList(attrs);
@@ -784,7 +784,7 @@ public abstract class Model extends CallbackSupport implements Externalizable {
                       .replaceAll("\t", "\\\\t")      // \t
                       + "\"";
             }
-            attributeStrings.add((pretty ? "\n  " + indent : "") + "\"" + name + "\":" + val + "");
+            attributeStrings.add((pretty ? "\n  " + indent : "") + "\"" + name + "\":" + val);
         }
 
         sw.write(Util.join(attributeStrings, ","));


### PR DESCRIPTION
Hi javalite team,
I am not sure why Model#toJson prints out every attribute in String form,
also not sure why "model_class" is needed (it's not even used in Model#fromMap when I try to rebuild the model from JSON string).

This patch tries to print JSON according json.org spec, also fixed an existing String escape bug.
But this still ignores all binary data types, it could be better to refactor Model#toJson and LazyList#toJson with Jackson JSON generation.

With current Model#toJson behaviour, I think I am not the only one having trouble in client side Javascript coding.
Please consider whether this patch is appropriate.

Chunpeng
