### PR TITLE
Added support for SELECT EXISTS queries for fast checking for row existence

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -544,6 +544,21 @@ public abstract class Model extends CallbackSupport implements Externalizable {
     }
 
     /**
+     * Returns true if there is a single record matching the subquery in the DB
+     * @param subquery selection criteria, example:
+     * <pre>
+     * boolean exists = Person.exists("name = ? and age &lt 13", "John")
+     * </pre>
+     * @param params list of parameters if question marks are used as placeholders
+     * @return true if a single matching record exists, false otherwise.
+     */
+    public static boolean exists(String subquery, Object... params){
+        MetaModel metaModel = getMetaModel();
+        return null != new DB(metaModel.getDbName()).firstCell("SELECT EXISTS (SELECT 1 FROM " + metaModel.getTableName()
+                + " WHERE " + subquery + ")", params);
+    }
+
+    /**
      * Returns true if record corresponding to the id of this instance exists in  the DB.
      *
      * @return true if corresponding record exists in DB, false if it does not.

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ModelExistsTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ModelExistsTest.java
@@ -40,4 +40,13 @@ public class ModelExistsTest extends ActiveJDBCTest {
         Person.delete("id = ?", p.getId());
         a(p.exists()).shouldBeFalse();
     }
+
+    @Test
+    public void testExistsWithWhereClause(){
+        deleteAndPopulateTable("people");
+        a(Person.exists("id = 10000")).shouldBeFalse();
+        Person p = Person.<Person>findAll().get(0);
+        a(Person.exists("id = ?", p.getId())).shouldBeTrue();
+        a(Person.exists("name = ?", "John")).shouldBeTrue();
+    }
 }


### PR DESCRIPTION
Had a case where I just need to quickly check if something exists before paying the cost of querying for it, which will happen relatively infrequently.  Model.findFirst works pretty well, but this should be even faster.
