### PR TITLE
Fixed problems where a non-PK field named "id" is present.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -1045,7 +1045,7 @@ public abstract class Model extends CallbackSupport implements Externalizable {
 
         // NOTE: this is a workaround for JSP pages. JSTL in cases ${item.id} does not call the getId() method, instead
         //calls item.get("id"), considering that this is a map only!        
-        if(attribute.equalsIgnoreCase("id")){
+        if(!attributes.containsKey("id") && attribute.equalsIgnoreCase("id")){
             String idName = getMetaModelLocal().getIdName();
             return attributes.get(idName.toLowerCase());
         }


### PR DESCRIPTION
I had a problem with a table which has PK `entry` and a field named `id`.

When updating field `id`, both `entry` and `id` would be set to the new value. This is incorrect behavior.

This change fixes the problem.
