### PR TITLE
Closing statement cache prepared statements on cleanStatementCache.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/StatementCache.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/StatementCache.java
@@ -46,6 +46,11 @@ class StatementCache {
     }
 
     void cleanStatementCache(Connection connection) {
-        statementCache.remove(connection);
+       Map<String, PreparedStatement> stmsMap = statementCache.remove(connection);
+	   if(stmsMap != null) { //Close prepared statements to release cursors on connection pools
+			for(PreparedStatement stmt : stmsMap.values()) {
+				try{stmt.close();}catch(Exception e){}
+			}
+	   }
     }
 }


### PR DESCRIPTION
Closing prepared statements when cleaning statement cache. 
This will close database cursors when using a connection pool. See problem description at https://code.google.com/p/activeweb/issues/detail?id=135
