### PR TITLE
Bug Fix - add catch of SQLException and SQLFeatureNotSupportedException

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/DB.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/DB.java
@@ -558,6 +558,10 @@ public class DB {
                         ps.setBlob(index + 1, b);
                     } catch (AbstractMethodError e) {// net.sourceforge.jtds.jdbc.ConnectionJDBC2.createBlob is abstract :)
                         ps.setObject(index + 1, param);
+                    } catch (SQLFeatureNotSupportedException e) {
+                        ps.setObject(index + 1, param);
+                    } catch (SQLException e) {
+                        ps.setObject(index + 1, param);
                     }
                 }else{
                     ps.setObject(index + 1, param);


### PR DESCRIPTION
Added catch of SQLException and SQLFeatureNotSupportedException since not all implementations of JDBC drivers support createBlob/setBlob.
