### PR TITLE
Add a gradle plugin project for parity with maven

### DIFF
--- a/activejdbc-gradle-plugin/build.gradle
+++ b/activejdbc-gradle-plugin/build.gradle
@@ -1,0 +1,18 @@
+group 'org.javalite'
+version '1.4.9'
+
+apply plugin: 'groovy'
+apply plugin: 'maven'
+
+sourceCompatibility = 1.7
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile gradleApi()
+    compile localGroovy()
+    compile group: 'org.javalite', name: 'activejdbc', version: '1.4.9'
+    compile group: 'org.javalite', name: 'activejdbc-instrumentation', version: '1.4.9'
+}

--- a/activejdbc-gradle-plugin/gradlew
+++ b/activejdbc-gradle-plugin/gradlew
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+##############################################################################
+##
+##  Gradle start up script for UN*X
+##
+##############################################################################
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "$*"
+}
+
+die ( ) {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+esac
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched.
+if $cygwin ; then
+    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+fi
+
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >&-
+APP_HOME="`pwd -P`"
+cd "$SAVED" >&-
+
+CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
+
+# Determine the Java command to use to start the JVM.
+if [ -n "$JAVA_HOME" ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ $? -eq 0 ] ; then
+        if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
+            MAX_FD="$MAX_FD_LIMIT"
+        fi
+        ulimit -n $MAX_FD
+        if [ $? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: $MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: $MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if $darwin; then
+    GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin ; then
+    APP_HOME=`cygpath --path --mixed "$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in $ROOTDIRSRAW ; do
+        ROOTDIRS="$ROOTDIRS$SEP$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^($ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="$OURCYGPATTERN|($GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "$@" ; do
+        CHECK=`echo "$arg"|egrep -c "$OURCYGPATTERN" -`
+        CHECK2=`echo "$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ $CHECK -ne 0 ] && [ $CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args$i`=`cygpath --path --ignore --mixed "$arg"`
+        else
+            eval `echo args$i`="\"$arg\""
+        fi
+        i=$((i+1))
+    done
+    case $i in
+        (0) set -- ;;
+        (1) set -- "$args0" ;;
+        (2) set -- "$args0" "$args1" ;;
+        (3) set -- "$args0" "$args1" "$args2" ;;
+        (4) set -- "$args0" "$args1" "$args2" "$args3" ;;
+        (5) set -- "$args0" "$args1" "$args2" "$args3" "$args4" ;;
+        (6) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" ;;
+        (7) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" ;;
+        (8) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" ;;
+        (9) set -- "$args0" "$args1" "$args2" "$args3" "$args4" "$args5" "$args6" "$args7" "$args8" ;;
+    esac
+fi
+
+# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
+function splitJvmOpts() {
+    JVM_OPTS=("$@")
+}
+eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
+JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+
+exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/activejdbc-gradle-plugin/gradlew.bat
+++ b/activejdbc-gradle-plugin/gradlew.bat
@@ -1,0 +1,90 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windowz variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+if "%@eval[2+2]" == "4" goto 4NT_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+goto execute
+
+:4NT_args
+@rem Get arguments from the 4NT Shell from JP Software
+set CMD_LINE_ARGS=%$
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/activejdbc-gradle-plugin/settings.gradle
+++ b/activejdbc-gradle-plugin/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'activejdbc-gradle-plugin'

--- a/activejdbc-gradle-plugin/src/main/groovy/org/javalite/instrumentation/gradle/ActiveJDBCGradlePlugin.groovy
+++ b/activejdbc-gradle-plugin/src/main/groovy/org/javalite/instrumentation/gradle/ActiveJDBCGradlePlugin.groovy
@@ -1,0 +1,18 @@
+package org.javalite.instrumentation.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Gradle plugin the registers an {@link ActiveJDBCInstrumentation} task to run as part of the classes step.
+ */
+class ActiveJDBCGradlePlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        project.tasks.create('instrumentModels', ActiveJDBCInstrumentation)
+        project.tasks.instrumentModels.dependsOn << 'compileJava'
+        project.tasks.classes.dependsOn << 'instrumentModels'
+    }
+
+}

--- a/activejdbc-gradle-plugin/src/main/groovy/org/javalite/instrumentation/gradle/ActiveJDBCInstrumentation.groovy
+++ b/activejdbc-gradle-plugin/src/main/groovy/org/javalite/instrumentation/gradle/ActiveJDBCInstrumentation.groovy
@@ -1,0 +1,58 @@
+package org.javalite.instrumentation.gradle
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.javalite.instrumentation.Instrumentation
+
+/**
+ * Gradle task for performing ActiveJDBC instrumentation on a set of compiled {@code .class} files.
+ */
+class ActiveJDBCInstrumentation extends DefaultTask {
+
+    /** The directory containing class files to be instrumented. */
+    String classesDir = project.sourceSets.main.output.classesDir.getPath()
+
+    /** The output directory to write back classes after instrumentation. */
+    String outputDir = classesDir
+
+    ActiveJDBCInstrumentation() {
+        description = "Instrument compiled class files extending from 'org.javalite.activejdbc.Model'"
+    }
+
+    @TaskAction
+    def instrument() {
+        Instrumentation instrumentation = new Instrumentation()
+        instrumentation.outputDirectory = outputDir ?: classesDir
+
+        def rootLoader = this.class.classLoader.rootLoader
+        addUrlIfNotPresent rootLoader, classesDir
+        addUrlIfNotPresent Instrumentation.class.classLoader, classesDir
+        instrumentation.instrument()
+    }
+
+    // from the Griffon ActiveJDBC plugin
+    private def addUrlIfNotPresent(to, what) {
+        if (!to || !what) {
+            return
+        }
+        def urls = to.URLs.toList()
+        switch (what.class) {
+            case URL: what = new File(what.toURI()); break
+            case String: what = new File(what); break
+            case GString: what = new File(what.toString()); break
+            case File: break; // ok
+            default:
+                println "Don't know how to deal with $what as it is not an URL nor a File"
+                System.exit(1)
+        }
+
+        if (what.directory && !what.exists()) {
+            what.mkdirs()
+        }
+        def url = what.toURI().toURL()
+        if (!urls.contains(url) && (what.directory || !urls.find { it.path.endsWith(what.name) })) {
+            to.addURL(url)
+        }
+    }
+
+}

--- a/activejdbc-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.javalite.activejdbc.properties
+++ b/activejdbc-gradle-plugin/src/main/resources/META-INF/gradle-plugins/org.javalite.activejdbc.properties
@@ -1,0 +1,1 @@
+implementation-class=org.javalite.instrumentation.gradle.ActiveJDBCGradlePlugin


### PR DESCRIPTION
Hi, I really like ActiveJDBC and thought it might be useful to have a proper gradle plugin. 

The custom build script example in [javalite/activejdbc-gradle](https://github.com/javalite/activejdbc-gradle) works just fine (in fact the plugin is 99% just the code from the example), but does have the drawback that if the instrumentation process were ever to change everyone who copied the example would need to update their build.

If you are not interested in having this as part of the main repository let me know. I just assumed since the maven plugin is here perhaps you would want to merge in a gradle one too.

**Testing**

I converted the [gradle example to use the plugin here](https://github.com/jasoma/activejdbc-gradle/tree/gradle-plugin) so you can see the difference in the build script. Please note that the version linked there assumes that the plugin was published (it obviously has not been) and when I was testing there was an additional `mavenLocal()` repository configuration in the build script[1].


[1] *I also converted it to H2 instead of MySQL but I can revert that if it is not wanted*