### PR TITLE
Setup the gradle plugin build to be platform agnostic #430

### DIFF
--- a/activejdbc-gradle-plugin/pom.xml
+++ b/activejdbc-gradle-plugin/pom.xml
@@ -30,6 +30,31 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>Windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <gradleScript>.\gradlew.bat</gradleScript>
+            </properties>
+        </profile>
+        <profile>
+            <id>unix</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <properties>
+                <gradleScript>./gradlew</gradleScript>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <!-- Runs the gradle managed build which will produce all artifacts -->
@@ -46,7 +71,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <executable>./gradlew</executable>
+                    <executable>${gradleScript}</executable>
                     <arguments>
                         <argument>build</argument>
                     </arguments>


### PR DESCRIPTION
Choose which gradle wrapper script to execute based on OS family.

**Testing**

- Builds via maven on Windows-10 (powershell) and OSX
  - maven install suceeds
  - All artifacts (class, sources, and doc jars) present in the ouput
- `mvn exec:exec` succeeds for the plugin project on Ubuntu

**Caveats**

I had to comment out the builds of the `db-migrator` and `db-migrator-integration-test` modules since I don't have a MySql instance running which they expect. 

Could not fully test on Ubuntu since I get this error when trying to build the main `activejdbc` module:

```
Failed to execute goal org.javalite:activejdbc-instrumentation:1.4.12-SNAPSHOT:instrument (default) on project activejdbc: The parameters 'project' for goal org.javalite:activejdbc-instrumentation:1.4.12-SNAPSHOT:instrument are missing or invalid
```
I am not sure why the error is here since it didn't occur on either OSX or Windows. But it happens even on the master branch so I'm going to assume it is not an issue.