### PR TITLE
Fix the class file copying from gradle output to maven output

### DIFF
--- a/activejdbc-gradle-plugin/build.gradle
+++ b/activejdbc-gradle-plugin/build.gradle
@@ -34,7 +34,7 @@ task sourceJar(type: Jar) {
 
 // copy the compiled classes into the maven output dir so it can assemble the jar
 task moveClasses(type: Copy, dependsOn: 'compileGroovy') {
-    from "$buildDir/classes"
+    from sourceSets.main.output
     into 'target/classes'
 }
 


### PR DESCRIPTION
Fix an inconsistency between the maven/gradle build conventions that was causing the gradle-plugin jar to have classes at the wrong paths. Previously the gradle build was copying the entire `build/classes` dir into `target` and maven was constructing/signing the jar. The problem is this would include `main` as part of the paths in the jar:

```shell
$ jar tvf target/activejdbc-gradle-plugin-1.4.12-SNAPSHOT.jar 
     0 Mon Nov 09 10:57:58 JST 2015 META-INF/
   130 Mon Nov 09 10:57:56 JST 2015 META-INF/MANIFEST.MF
     0 Mon Nov 09 10:57:56 JST 2015 main/
     0 Mon Nov 09 10:57:56 JST 2015 main/org/
     0 Mon Nov 09 10:57:56 JST 2015 main/org/javalite/
     0 Mon Nov 09 10:57:56 JST 2015 main/org/javalite/instrumentation/
     0 Mon Nov 09 10:57:56 JST 2015 main/org/javalite/instrumentation/gradle/
     0 Mon Nov 09 10:57:52 JST 2015 META-INF/gradle-plugins/
  6153 Mon Nov 09 10:57:56 JST 2015 main/org/javalite/instrumentation/gradle/ActiveJDBCGradlePlugin.class
  3292 Mon Nov 09 10:57:56 JST 2015 main/org/javalite/instrumentation/gradle/ActiveJDBCInstrumentation$_addUrlIfNotPresent_closure1.class
 16417 Mon Nov 09 10:57:56 JST 2015 main/org/javalite/instrumentation/gradle/ActiveJDBCInstrumentation.class
    80 Mon Nov 09 10:57:52 JST 2015 META-INF/gradle-plugins/org.javalite.activejdbc.properties
     0 Mon Nov 09 10:57:58 JST 2015 META-INF/maven/
     0 Mon Nov 09 10:57:58 JST 2015 META-INF/maven/org.javalite/
     0 Mon Nov 09 10:57:58 JST 2015 META-INF/maven/org.javalite/activejdbc-gradle-plugin/
  2682 Mon Nov 09 10:40:36 JST 2015 META-INF/maven/org.javalite/activejdbc-gradle-plugin/pom.xml
   131 Mon Nov 09 10:57:56 JST 2015 META-INF/maven/org.javalite/activejdbc-gradle-plugin/pom.properties
```

This changes the copy step to use the output of the main compile instead of the root classes dir. Classes are now at the correct paths in the jar:

```shell
jar tvf target/activejdbc-gradle-plugin-1.4.12-SNAPSHOT.jar 
     0 Mon Nov 09 11:02:00 JST 2015 META-INF/
   130 Mon Nov 09 11:01:58 JST 2015 META-INF/MANIFEST.MF
     0 Mon Nov 09 11:01:56 JST 2015 META-INF/gradle-plugins/
     0 Mon Nov 09 11:02:00 JST 2015 org/
     0 Mon Nov 09 11:02:00 JST 2015 org/javalite/
     0 Mon Nov 09 11:02:00 JST 2015 org/javalite/instrumentation/
     0 Mon Nov 09 11:02:00 JST 2015 org/javalite/instrumentation/gradle/
    80 Mon Nov 09 11:02:00 JST 2015 META-INF/gradle-plugins/org.javalite.activejdbc.properties
  6153 Mon Nov 09 11:02:00 JST 2015 org/javalite/instrumentation/gradle/ActiveJDBCGradlePlugin.class
  3292 Mon Nov 09 11:02:00 JST 2015 org/javalite/instrumentation/gradle/ActiveJDBCInstrumentation$_addUrlIfNotPresent_closure1.class
 16417 Mon Nov 09 11:02:00 JST 2015 org/javalite/instrumentation/gradle/ActiveJDBCInstrumentation.class
     0 Mon Nov 09 11:02:00 JST 2015 META-INF/maven/
     0 Mon Nov 09 11:02:00 JST 2015 META-INF/maven/org.javalite/
     0 Mon Nov 09 11:02:00 JST 2015 META-INF/maven/org.javalite/activejdbc-gradle-plugin/
  2682 Mon Nov 09 10:40:36 JST 2015 META-INF/maven/org.javalite/activejdbc-gradle-plugin/pom.xml
   131 Mon Nov 09 11:02:00 JST 2015 META-INF/maven/org.javalite/activejdbc-gradle-plugin/pom.properties
```
