### PR TITLE
Ehcache3

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/cache/EHCache3Manager.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/cache/EHCache3Manager.java
@@ -77,8 +77,9 @@ public class EHCache3Manager extends CacheManager {
         if (event.getType().equals(CacheEvent.CacheEventType.ALL)) {
             logger.warn(getClass() + " does not support flushing all caches. Flush one group at the time.");
         } else if (event.getType().equals(CacheEvent.CacheEventType.GROUP)) {
-            synchronized (lock) {
-                cacheManager.removeCache(event.getGroup());
+            final Cache<String, Object> cache = cacheManager.getCache(event.getGroup(), String.class, Object.class);
+            if (cache != null) {
+                cache.clear();
             }
         }
     }


### PR DESCRIPTION
I have done 2 commits:
 - First, shows how to use the template for creating each cache
 - Second, clears the cache rather than removing it

The issue with removing the cache is that it introduces a race situation:
 - T1 retrieves a `Cache` instance from the `CacheManager`
 - T2 removes the `Cache` from the `CacheManager`
 - T1 puts or gets from the `Cache` instance retrieved: throws exception!

You can't use a `Cache` instance that was `.close()`'d by the `CacheManager`