### PR TITLE
Code quality fix - Modifiers should be declared in the correct order

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Configuration.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Configuration.java
@@ -36,7 +36,7 @@ public class Configuration {
     private Map<String, List<String>> modelsMap = new HashMap<String, List<String>>();
     private Properties properties = new Properties();
     private static CacheManager cacheManager;
-    private final static Logger logger = LoggerFactory.getLogger(Configuration.class);
+    private static final Logger logger = LoggerFactory.getLogger(Configuration.class);
 
     private Map<String, Dialect> dialects = new CaseInsensitiveMap<>();
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/ConnectionsAccess.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/ConnectionsAccess.java
@@ -27,7 +27,7 @@ import java.util.*;
  * @author Igor Polevoy
  */
 public class ConnectionsAccess {
-    private final static Logger logger = LoggerFactory.getLogger(ConnectionsAccess.class);
+    private static final Logger logger = LoggerFactory.getLogger(ConnectionsAccess.class);
     private static final ThreadLocal<HashMap<String, Connection>> connectionsTL = new ThreadLocal<HashMap<String, Connection>>();
 
     static Map<String, Connection> getConnectionMap(){

--- a/activejdbc/src/main/java/org/javalite/activejdbc/DB.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/DB.java
@@ -42,7 +42,7 @@ import static org.javalite.common.Util.empty;
  */
 public class DB {
 
-    private final static Logger logger = LoggerFactory.getLogger(DB.class);
+    private static final Logger logger = LoggerFactory.getLogger(DB.class);
     static final Pattern SELECT_PATTERN = Pattern.compile("^\\s*SELECT",
             Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
     static final Pattern INSERT_PATTERN = Pattern.compile("^\\s*INSERT",

--- a/activejdbc/src/main/java/org/javalite/activejdbc/MetaModel.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/MetaModel.java
@@ -30,7 +30,7 @@ import static org.javalite.common.Util.*;
 
 
 public class MetaModel implements Serializable {
-    private final static Logger logger = LoggerFactory.getLogger(MetaModel.class);
+    private static final Logger logger = LoggerFactory.getLogger(MetaModel.class);
 
     private Map<String, ColumnMetadata> columnMetadata;
     private final List<Association> associations = new ArrayList<Association>();

--- a/activejdbc/src/main/java/org/javalite/activejdbc/MetaModels.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/MetaModels.java
@@ -26,7 +26,7 @@ import java.util.*;
  */
 class MetaModels {
 
-    private final static Logger logger = LoggerFactory.getLogger(MetaModels.class);
+    private static final Logger logger = LoggerFactory.getLogger(MetaModels.class);
 
     private final Map<String, MetaModel> metaModelsByTableName = new CaseInsensitiveMap<MetaModel>();
     private final Map<Class<? extends Model>, MetaModel> metaModelsByClass = new HashMap<Class<? extends Model>, MetaModel>();

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -56,7 +56,7 @@ import static org.javalite.common.Util.join;
  */
 public abstract class Model extends CallbackSupport implements Externalizable {
 
-    private final static Logger logger = LoggerFactory.getLogger(Model.class);
+    private static final Logger logger = LoggerFactory.getLogger(Model.class);
 
     private Map<String, Object> attributes = new CaseInsensitiveMap<Object>();
     private final Set<String> dirtyAttributeNames = new CaseInsensitiveSet();

--- a/activejdbc/src/main/java/org/javalite/activejdbc/ModelDelegate.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/ModelDelegate.java
@@ -34,7 +34,7 @@ import static org.javalite.common.Util.*;
  * @author Eric Nielsen
  */
 public final class ModelDelegate {
-    private final static Logger logger = LoggerFactory.getLogger(ModelDelegate.class);
+    private static final Logger logger = LoggerFactory.getLogger(ModelDelegate.class);
 
     private ModelDelegate() {
         // not instantiable

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Registry.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Registry.java
@@ -42,7 +42,7 @@ public enum Registry {
     //our singleton!
     INSTANCE;
 
-    private final static Logger logger = LoggerFactory.getLogger(Registry.class);
+    private static final Logger logger = LoggerFactory.getLogger(Registry.class);
 
     private final MetaModels metaModels = new MetaModels();
     private final Map<Class, ModelRegistry> modelRegistries = new HashMap<Class, ModelRegistry>();

--- a/activejdbc/src/main/java/org/javalite/activejdbc/cache/CacheManager.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/cache/CacheManager.java
@@ -30,7 +30,7 @@ import java.util.List;
  * @author Igor Polevoy
  */
 public abstract class CacheManager {
-    private final static Logger logger = LoggerFactory.getLogger(CacheManager.class);
+    private static final Logger logger = LoggerFactory.getLogger(CacheManager.class);
 
     List<CacheEventListener> listeners = new ArrayList<CacheEventListener>();
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/cache/QueryCache.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/cache/QueryCache.java
@@ -35,7 +35,7 @@ import static org.javalite.common.Util.*;
 public enum QueryCache {
     INSTANCE;
 
-    private final static Logger logger = LoggerFactory.getLogger(QueryCache.class);
+    private static final Logger logger = LoggerFactory.getLogger(QueryCache.class);
 
     private final boolean enabled = Registry.instance().getConfiguration().cacheEnabled();
 

--- a/javalite-common/src/main/java/org/javalite/common/XmlEntities.java
+++ b/javalite-common/src/main/java/org/javalite/common/XmlEntities.java
@@ -137,7 +137,7 @@ public class XmlEntities {
         }
     }
 
-    static abstract class MapIntMap implements XmlEntities.EntityMap {
+    abstract static class MapIntMap implements XmlEntities.EntityMap {
         protected final Map mapNameToValue;
 
         protected final Map mapValueToName;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.

Faisal