### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/activejdbc-instrumentation/src/main/java/org/javalite/instrumentation/JavaAgent.java
+++ b/activejdbc-instrumentation/src/main/java/org/javalite/instrumentation/JavaAgent.java
@@ -42,6 +42,10 @@ public class JavaAgent {
     private static final Set<ClassLoader> loaders = new HashSet<ClassLoader>();
     private static Method modelFound;
 
+    private JavaAgent() {
+        
+    }
+    
     @SuppressWarnings("unchecked")
     public static void premain(String args, java.lang.instrument.Instrumentation inst) {
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Base.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Base.java
@@ -36,6 +36,10 @@ import java.util.Properties;
  */
 public class Base {
 
+    private Base() {
+        
+    }
+    
     /**
      * This method will open a connection defined in the file 'database.properties' located at
      * root of classpath. The connection picked from the file is defined by <code>ACTIVE_ENV</code>

--- a/activejdbc/src/main/java/org/javalite/activejdbc/ConnectionsAccess.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/ConnectionsAccess.java
@@ -30,6 +30,10 @@ public class ConnectionsAccess {
     private final static Logger logger = LoggerFactory.getLogger(ConnectionsAccess.class);
     private static final ThreadLocal<HashMap<String, Connection>> connectionsTL = new ThreadLocal<HashMap<String, Connection>>();
 
+    private ConnectionsAccess() {
+        
+    }
+    
     static Map<String, Connection> getConnectionMap(){
         if (connectionsTL.get() == null)
             connectionsTL.set(new HashMap<String, Connection>());

--- a/activejdbc/src/main/java/org/javalite/activejdbc/LogFilter.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/LogFilter.java
@@ -42,6 +42,10 @@ public class LogFilter {
             setLogExpression("a{10000000}");
         }
     }
+    
+    private LogFilter() {
+        
+    }
 
     public static void setLogExpression(String regexp){
         pattern = Pattern.compile(regexp, Pattern.CASE_INSENSITIVE);

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Messages.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Messages.java
@@ -34,6 +34,10 @@ public class Messages {
 
     private static final String BUNDLE = "activejdbc_messages";
 
+    private Messages() {
+        
+    }
+    
     /**
      * Looks for a localized property/message in <code>activejdbc_messages</code> bundle.
      *

--- a/activejdbc/src/main/java/org/javalite/activejdbc/ModelFinder.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/ModelFinder.java
@@ -29,6 +29,10 @@ public class ModelFinder {
 
     private static final List<String> modelClassNames = new ArrayList<String>();
 
+    private ModelFinder() {
+        
+    }
+    
     protected static void findModels(String dbName) throws IOException, ClassNotFoundException {
         //this is for static instrumentation. In case of dynamic, the  modelClassNames will already be filled.
         List<String> models = Registry.instance().getConfiguration().getModelNames(dbName);

--- a/db-migrator/src/main/java/org/javalite/db_migrator/DbUtils.java
+++ b/db-migrator/src/main/java/org/javalite/db_migrator/DbUtils.java
@@ -24,6 +24,10 @@ public class DbUtils {
     private static final String DB2_FRAGMENT = ":db2:";
     private static final String ORACLE_FRAGMENT = ":oracle:";
 
+    private DbUtils() {
+        
+    }
+    
     /**
      * Given a jdbc url, this tries to determine the target database and returns the driver class name as a string.
      *

--- a/javalite-common/src/main/java/org/javalite/common/Inflector.java
+++ b/javalite-common/src/main/java/org/javalite/common/Inflector.java
@@ -89,6 +89,10 @@ public class Inflector {
 
         uncountables = Arrays.asList("equipment", "information", "rice", "money", "species", "series", "fish", "sheep");
     }
+    
+    private Inflector() {
+        
+    }
 
     public static void addPlural(String rule, String replacement){
         plurals.add(0, new String[]{rule, replacement});

--- a/javalite-common/src/main/java/org/javalite/http/Http.java
+++ b/javalite-common/src/main/java/org/javalite/http/Http.java
@@ -37,8 +37,10 @@ public class Http {
      * Read timeout in milliseconds. Set this value to what you like to override default.
      */
     public static int READ_TIMEOUT = 5000;
-
-
+    
+    private Http() {
+        
+    }
 
     /**
      * Executes a POST request.

--- a/javalite-common/src/main/java/org/javalite/test/SystemStreamUtil.java
+++ b/javalite-common/src/main/java/org/javalite/test/SystemStreamUtil.java
@@ -15,6 +15,10 @@ public class SystemStreamUtil {
     private static ByteArrayOutputStream outStream;
     private static ByteArrayOutputStream errorStream;
 
+    private SystemStreamUtil() {
+        
+    }
+    
     /**
      * Replaces <code>System.out</code> with internal buffer. All calls such as <code>System.out.print...</code>
      * will go to this buffer and not to STDIO

--- a/javalite-common/src/main/java/org/javalite/test/jspec/JSpec.java
+++ b/javalite-common/src/main/java/org/javalite/test/jspec/JSpec.java
@@ -19,6 +19,10 @@ package org.javalite.test.jspec;
 
 public final class JSpec{
     
+    private JSpec() {
+        
+    }
+    
     public static Expectation<Object> a(Object o1){
         return new Expectation<Object>(o1);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of rule: 
squid:S1118 - Utility classes should not have public constructors.

You can find more information about the issue here:
http://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal