### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/git-info-maven-plugin/src/main/java/org/javalite/maven/GitInfo.java
+++ b/git-info-maven-plugin/src/main/java/org/javalite/maven/GitInfo.java
@@ -33,6 +33,10 @@ public class GitInfo {
     public static void main(String[] args) throws IOException {
         System.out.println(genHtml());
     }
+    
+    private GitInfo() {
+        
+    }
 
 
     protected static String genHtml() {

--- a/javalite-common/src/main/java/org/javalite/common/JsonHelper.java
+++ b/javalite-common/src/main/java/org/javalite/common/JsonHelper.java
@@ -15,6 +15,11 @@ import java.util.Map;
 
 public class JsonHelper {
     private static final ObjectMapper mapper = new ObjectMapper();
+    
+    private JsonHelper() {
+        
+    }
+    
     static {
         mapper.configure(SerializationConfig.Feature.WRITE_DATES_AS_TIMESTAMPS, false);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed