### PR TITLE
Code quality fix - "@Override" annotation should be used on any method overriding.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/associations/Many2ManyAssociation.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/associations/Many2ManyAssociation.java
@@ -73,6 +73,7 @@ public class Many2ManyAssociation extends Association {
         return getSourceClass().getSimpleName() + "  >---------<  " + getTargetClass().getSimpleName() + ", type: " + "many-to-many" + ", join: " + join;
     }
 
+    @Override
     public boolean equals(Object other) {
 
         if(other == null || !other.getClass().equals(getClass())){

--- a/activejdbc/src/test/java/org/javalite/activejdbc/BaseTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/BaseTest.java
@@ -40,6 +40,7 @@ public class BaseTest extends ActiveJDBCTest {
         final List<Map> records = new ArrayList<Map>();
 
         Base.find("select * from people order by id", new RowListenerAdapter() {
+            @Override
             public void onNext(Map record) {
                 records.add(record);
             }

--- a/activejdbc/src/test/java/org/javalite/activejdbc/BelongsToParentsTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/BelongsToParentsTest.java
@@ -9,7 +9,8 @@ import org.javalite.activejdbc.test_models.Motherboard;
 
 public class BelongsToParentsTest extends ActiveJDBCTest {
 
-	public void before() throws Exception { 
+	@Override
+    public void before() throws Exception { 
 		super.before();
 
         deleteFromTable("computers");

--- a/activejdbc/src/test/java/org/javalite/activejdbc/CacheEventListenerTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/CacheEventListenerTest.java
@@ -17,6 +17,7 @@ import java.io.PrintStream;
  */
 public class CacheEventListenerTest extends ActiveJDBCTest {
 
+    @Override
     @After
     public void after(){
         super.after();

--- a/activejdbc/src/test/java/org/javalite/activejdbc/Issue137Spec.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/Issue137Spec.java
@@ -35,6 +35,7 @@ public class Issue137Spec extends ActiveJDBCTest {
         Person.callbackWith(adapter);
     }
 
+    @Override
     @Before
     public void before() throws Exception {
         super.before();

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ModelTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ModelTest.java
@@ -143,6 +143,7 @@ public class ModelTest extends ActiveJDBCTest {
         deleteAndPopulateTable("people");
         final Person p = new Person();
         expect(new ExceptionExpectation(IllegalArgumentException.class) {
+            @Override
             public void exec() {
                 p.set("NAME1", "Igor");
             }
@@ -155,6 +156,7 @@ public class ModelTest extends ActiveJDBCTest {
         final Person p = new Person();
 
         expect(new ExceptionExpectation(IllegalArgumentException.class) {
+            @Override
             public void exec() {
                 p.set("person_id", "hehe");
             }
@@ -237,6 +239,7 @@ public class ModelTest extends ActiveJDBCTest {
     public void testBatchUpdateAll() {
         deleteAndPopulateTable("people");
         expect(new DifferenceExpectation(Person.find("last_name like ?", "Smith").size()) {
+            @Override
             public Object exec() {
                 Person.updateAll("last_name = ?", "Smith");
                 return Person.find("last_name like ?", "Smith").size();
@@ -276,12 +279,14 @@ public class ModelTest extends ActiveJDBCTest {
         deleteAndPopulateTables("users", "addresses");
         final User user = User.findById(1);
         expect(new ExceptionExpectation(NotAssociatedException.class){
+            @Override
             public void exec() {
                 user.getAll(Book.class);//wrong table
             }
         });
 
         expect(new ExceptionExpectation(NotAssociatedException.class){
+            @Override
             public void exec() {
                 user.getAll(Book.class);//non-existent table
             }
@@ -409,12 +414,14 @@ public class ModelTest extends ActiveJDBCTest {
         a.delete();
 
         expect(new ExceptionExpectation(FrozenException.class) {
+            @Override
             public void exec() {
                 a.saveIt();
             }
         });
 
         expect(new ExceptionExpectation(FrozenException.class) {
+            @Override
             public void exec() {
                 u.add(a);
             }
@@ -590,6 +597,7 @@ public class ModelTest extends ActiveJDBCTest {
     public void shouldCreateModelWithSingleSetter(){
         deleteAndPopulateTable("people");
         expect(new DifferenceExpectation(Person.count()) {
+            @Override
             public Object exec() {
                 new Person().set("name", "Marilyn", "last_name", "Monroe", "dob", "1935-12-06").saveIt();
                 return (Person.count());

--- a/activejdbc/src/test/java/org/javalite/activejdbc/OrphanRecordTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/OrphanRecordTest.java
@@ -30,6 +30,7 @@ import java.util.List;
  */
 public class OrphanRecordTest extends ActiveJDBCTest {
 
+    @Override
     @Before
     public void before() throws Exception {
         super.before();

--- a/activejdbc/src/test/java/org/javalite/activejdbc/SetParentTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/SetParentTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
  */
 public class SetParentTest extends ActiveJDBCTest {
 
+    @Override
     @Before
     public void before() throws Exception {
         super.before();

--- a/activejdbc/src/test/java/org/javalite/activejdbc/TimeManagementSpec.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/TimeManagementSpec.java
@@ -13,6 +13,7 @@ import java.util.GregorianCalendar;
  */
 public class TimeManagementSpec extends ActiveJDBCTest {
 
+    @Override
     @Before
     public void before() throws Exception {
         super.before();

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ValidatorsTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ValidatorsTest.java
@@ -151,6 +151,7 @@ public class ValidatorsTest extends ActiveJDBCTest {
         //cause exception
         u.set("email", "this is not email value");
         expect(new ExceptionExpectation(ValidationException.class) {
+            @Override
             public void exec() {
                 u.saveIt();
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1161 - "@Override" annotation should be used on any method overriding.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal Hameed