### PR TITLE
Code quality fix - "entrySet()" should be iterated when both the key and value are needed.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Errors.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Errors.java
@@ -185,9 +185,9 @@ public class Errors implements Map<String, String> {
     public Set<Entry<String, String>> entrySet() {
         Set<Entry<String, String>> entries = new LinkedHashSet<Entry<String, String>>();
 
-        for(Object key: validators.keySet()){
-            String value = validators.get(key).formatMessage(locale);
-            entries.add(new ErrorEntry(key.toString(), value));
+        for(Entry<String, Validator> validator: validators.entrySet()){
+            String value = validator.getValue().formatMessage(locale);
+            entries.add(new ErrorEntry(validator.getKey(), value));
         }
         return entries;
     }

--- a/activejdbc/src/main/java/org/javalite/activejdbc/MetaModel.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/MetaModel.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.*;
+import java.util.Map.Entry;
 
 import static org.javalite.activejdbc.LogFilter.*;
 import static org.javalite.common.Inflector.*;
@@ -355,8 +356,8 @@ public class MetaModel implements Serializable {
         final StringBuilder t = new StringBuilder();
         t.append("MetaModel: ").append(tableName).append(", ").append(modelClass).append("\n");
         if(columnMetadata != null){
-            for (String key : columnMetadata.keySet()) {
-                t.append(columnMetadata.get(key)).append(", ");
+            for (Entry<String, ColumnMetadata> metadata : columnMetadata.entrySet()) {
+                t.append(metadata.getValue()).append(", ");
             }
         }
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -42,6 +42,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.util.*;
+import java.util.Map.Entry;
 
 import static org.javalite.activejdbc.ModelDelegate.metaModelFor;
 import static org.javalite.activejdbc.ModelDelegate.metaModelOf;
@@ -764,18 +765,18 @@ public abstract class Model extends CallbackSupport implements Externalizable {
             }
 
         }
-        for(Class parentClass: cachedParents.keySet()){
-            retVal.put(underscore(parentClass.getSimpleName()), cachedParents.get(parentClass).toMap());
+        for(Entry<Class, Model> parent: cachedParents.entrySet()){
+            retVal.put(underscore(parent.getKey().getSimpleName()), parent.getValue().toMap());
         }
 
-        for(Class childClass: cachedChildren.keySet()){
-            List<Model> children = cachedChildren.get(childClass);
+        for(Entry<Class, List<Model>> cachedChild: cachedChildren.entrySet()){
+            List<Model> children = cachedChild.getValue();
 
             List<Map> childMaps = new ArrayList<Map>(children.size());
             for(Model child:children){
                 childMaps.add(child.toMap());
             }
-            retVal.put(tableize(childClass.getSimpleName()), childMaps);
+            retVal.put(tableize(cachedChild.getKey().getSimpleName()), childMaps);
         }
         return retVal;
     }
@@ -873,12 +874,12 @@ public abstract class Model extends CallbackSupport implements Externalizable {
             sb.append("</").append(name).append('>');
             if (pretty) { sb.append('\n'); }
         }
-        for (Class childClass : cachedChildren.keySet()) {
+        for (Entry<Class, List<Model>> cachedChild : cachedChildren.entrySet()) {
             if (pretty) { sb.append("  ").append(indent); }
-            String tag = pluralize(underscore(childClass.getSimpleName()));
+            String tag = pluralize(underscore(cachedChild.getKey().getSimpleName()));
             sb.append('<').append(tag).append('>');
             if (pretty) { sb.append('\n'); }
-            for (Model child : cachedChildren.get(childClass)) {
+            for (Model child : cachedChild.getValue()) {
                 child.toXmlP(sb, pretty, "    " + indent);
             }
             if (pretty) { sb.append("  ").append(indent); }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.

Faisal Hameed