### PR TITLE
Code quality fix - "public static" fields should be constant.

### DIFF
--- a/javalite-common/src/main/java/org/javalite/http/Http.java
+++ b/javalite-common/src/main/java/org/javalite/http/Http.java
@@ -31,12 +31,12 @@ public class Http {
     /**
      * Connection timeout in milliseconds. Set this value to what you like to override default.
      */
-    public static int CONNECTION_TIMEOUT = 5000;
+    public static final int CONNECTION_TIMEOUT = 5000;
 
     /**
      * Read timeout in milliseconds. Set this value to what you like to override default.
      */
-    public static int READ_TIMEOUT = 5000;
+    public static final int READ_TIMEOUT = 5000;
     
     private Http() {
         


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1444 - "public static" fields should be constant
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1444

Please let me know if you have any questions.

Faisal Hameed