### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/activejdbc-instrumentation/src/main/java/org/javalite/instrumentation/InstrumentationModelFinder.java
+++ b/activejdbc-instrumentation/src/main/java/org/javalite/instrumentation/InstrumentationModelFinder.java
@@ -43,6 +43,7 @@ public class InstrumentationModelFinder {
     private final CtClass modelClass;
     private final List<CtClass> models = new ArrayList<CtClass>();
     private final ClassPool cp;
+    private String currentDirectoryPath;
 
 
     protected InstrumentationModelFinder() throws NotFoundException, ClassNotFoundException {
@@ -91,8 +92,6 @@ public class InstrumentationModelFinder {
         } catch (ClassNotFoundException ignore) {
         }
     }
-
-    private String currentDirectoryPath;
 
     protected void processDirectoryPath(File directory) throws IOException, ClassNotFoundException {
         currentDirectoryPath = directory.getCanonicalPath();

--- a/activejdbc/src/main/java/org/javalite/activejdbc/DBException.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/DBException.java
@@ -27,6 +27,11 @@ import static org.javalite.common.Util.*;
 public class DBException extends RuntimeException{
 
     final String message;
+    
+    public DBException() {
+        super();
+        this.message = null;
+    }
 
     public DBException(Throwable cause) {
         super(cause);
@@ -67,9 +72,5 @@ public class DBException extends RuntimeException{
     public String getMessage() {
         return message == null ? super.getMessage() : message;
     }
-
-    public DBException() {
-        super();
-        this.message = null;
-    }
+    
 }

--- a/activejdbc/src/main/java/org/javalite/activejdbc/StatementCache.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/StatementCache.java
@@ -32,11 +32,11 @@ import static org.javalite.common.Util.*;
 enum StatementCache {
     INSTANCE;
 
-    static StatementCache instance() { return INSTANCE; }
-
     private final ConcurrentMap<Connection, Map<String, PreparedStatement>> statementCache = new ConcurrentHashMap<Connection, Map<String, PreparedStatement>>();
 
     private StatementCache() { }
+    
+    static StatementCache instance() { return INSTANCE; }
 
     PreparedStatement getPreparedStatement(Connection connection, String query) {
         if (!statementCache.containsKey(connection)) {

--- a/app-config/src/main/java/org/javalite/app_config/AppConfig.java
+++ b/app-config/src/main/java/org/javalite/app_config/AppConfig.java
@@ -39,6 +39,10 @@ public class AppConfig implements Map<String, String> {
     private static Logger LOGGER = LoggerFactory.getLogger(AppConfig.class);
     private static HashMap<String, Property> props = new HashMap<String, Property>();
     private static HashMap<String, String> plainProps = new HashMap<String, String>();
+    
+    public AppConfig() {
+        init();
+    }
 
     public static synchronized void init() {
         if (isInited()) return;
@@ -156,11 +160,6 @@ public class AppConfig implements Map<String, String> {
 
 
     /////////// Implementation of Map interface below ///////////////////
-
-
-    public AppConfig() {
-        init();
-    }
 
     @Override
     public int size() {

--- a/javalite-common/src/main/java/org/javalite/common/Base64.java
+++ b/javalite-common/src/main/java/org/javalite/common/Base64.java
@@ -176,13 +176,6 @@ public class Base64 {
         private final boolean isURL;
         private final boolean doPadding;
 
-        private Encoder(boolean isURL, byte[] newline, int linemax, boolean doPadding) {
-            this.isURL = isURL;
-            this.newline = newline;
-            this.linemax = linemax;
-            this.doPadding = doPadding;
-        }
-
         /**
          * This array is a lookup table that translates 6-bit positive integer
          * index values into their "Base64 Alphabet" equivalents as specified
@@ -215,6 +208,13 @@ public class Base64 {
         static final Encoder RFC4648 = new Encoder(false, null, -1, true);
         static final Encoder RFC4648_URLSAFE = new Encoder(true, null, -1, true);
         static final Encoder RFC2045 = new Encoder(false, CRLF, MIMELINEMAX, true);
+        
+        private Encoder(boolean isURL, byte[] newline, int linemax, boolean doPadding) {
+            this.isURL = isURL;
+            this.newline = newline;
+            this.linemax = linemax;
+            this.doPadding = doPadding;
+        }
 
         private final int outLength(int srclen) {
             int len = 0;
@@ -451,11 +451,6 @@ public class Base64 {
         private final boolean isURL;
         private final boolean isMIME;
 
-        private Decoder(boolean isURL, boolean isMIME) {
-            this.isURL = isURL;
-            this.isMIME = isMIME;
-        }
-
         /**
          * Lookup table for decoding unicode characters drawn from the
          * "Base64 Alphabet" (as specified in Table 1 of RFC 2045) into
@@ -488,6 +483,11 @@ public class Base64 {
         static final Decoder RFC4648         = new Decoder(false, false);
         static final Decoder RFC4648_URLSAFE = new Decoder(true, false);
         static final Decoder RFC2045         = new Decoder(false, true);
+        
+        private Decoder(boolean isURL, boolean isMIME) {
+            this.isURL = isURL;
+            this.isMIME = isMIME;
+        }
 
         /**
          * Decodes all bytes from the input byte array using the {@link Base64}
@@ -856,13 +856,13 @@ public class Base64 {
         private boolean eof;
         private boolean closed;
 
+        private byte[] sbBuf = new byte[1];
+        
         DecInputStream(InputStream is, int[] base64, boolean isMIME) {
             this.is = is;
             this.base64 = base64;
             this.isMIME = isMIME;
         }
-
-        private byte[] sbBuf = new byte[1];
 
         @Override
         public int read() throws IOException {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed