### PR TITLE
Code quality fix - "Serializable" classes should have a version id.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Association.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Association.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 //TODO: move this class to associations package, but also see InstrumentationModelFinder:51
 public class Association implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+    
     private final Class<? extends Model> source;
     private final Class<? extends Model> target;
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/CaseInsensitiveMap.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/CaseInsensitiveMap.java
@@ -27,6 +27,8 @@ import java.util.TreeMap;
  */
 public class CaseInsensitiveMap<V> extends TreeMap<String, V> {
 
+    private static final long serialVersionUID = 1L;
+    
     public CaseInsensitiveMap() {
         super(String.CASE_INSENSITIVE_ORDER);
     }

--- a/activejdbc/src/main/java/org/javalite/activejdbc/CaseInsensitiveSet.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/CaseInsensitiveSet.java
@@ -27,6 +27,8 @@ import java.util.TreeSet;
  */
 public class CaseInsensitiveSet extends TreeSet<String> {
 
+    private static final long serialVersionUID = 1L;
+    
     public CaseInsensitiveSet() {
         super(String.CASE_INSENSITIVE_ORDER);
     }

--- a/activejdbc/src/main/java/org/javalite/activejdbc/ColumnMetadata.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/ColumnMetadata.java
@@ -21,6 +21,8 @@ import java.io.Serializable;
 
 public class ColumnMetadata implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+    
     private final String columnName;
     private final String typeName;
     private final int columnSize;

--- a/activejdbc/src/main/java/org/javalite/activejdbc/LazyList.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/LazyList.java
@@ -39,6 +39,8 @@ import static org.javalite.common.Util.*;
  */
 public class LazyList<T extends Model> extends AbstractLazyList<T> implements Externalizable {
 
+    private static final long serialVersionUID = 1L;
+    
     private static final Logger logger = LoggerFactory.getLogger(LazyList.class);
     private final List<String> orderBys = new ArrayList<String>();
     private final MetaModel metaModel;

--- a/activejdbc/src/main/java/org/javalite/activejdbc/MetaModel.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/MetaModel.java
@@ -30,6 +30,9 @@ import static org.javalite.common.Inflector.*;
 
 
 public class MetaModel implements Serializable {
+    
+    private static final long serialVersionUID = 1L;
+    
     private static final Logger logger = LoggerFactory.getLogger(MetaModel.class);
     private static final ThreadLocal<HashMap<Class, String>> shardingTableNamesTL = new ThreadLocal<>();
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Paginator.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Paginator.java
@@ -37,6 +37,9 @@ import static org.javalite.activejdbc.ModelDelegate.metaModelFor;
  * @author Igor Polevoy
  */
 public class Paginator<T extends Model> implements Serializable {
+    
+    private static final long serialVersionUID = 1L;
+    
     static final Pattern FROM_PATTERN = Pattern.compile("\\s+FROM\\s+", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
     private final int pageSize;

--- a/activejdbc/src/main/java/org/javalite/activejdbc/SuperLazyList.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/SuperLazyList.java
@@ -25,6 +25,8 @@ package org.javalite.activejdbc;
  * @author Igor Polevoy
  */
 public class SuperLazyList<T extends Model> extends LazyList<T> {
+    
+    private static final long serialVersionUID = 1L;
 
     protected SuperLazyList(){}
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/associations/BelongsToAssociation.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/associations/BelongsToAssociation.java
@@ -27,6 +27,8 @@ import org.javalite.activejdbc.Model;
  * @author Igor Polevoy
  */
 public class BelongsToAssociation extends Association {
+    
+    private static final long serialVersionUID = 1L;
 
     private final String fkName;
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/associations/BelongsToPolymorphicAssociation.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/associations/BelongsToPolymorphicAssociation.java
@@ -25,6 +25,8 @@ import org.javalite.activejdbc.Model;
  * @author Igor Polevoy
  */
 public class BelongsToPolymorphicAssociation extends Association {
+    
+    private static final long serialVersionUID = 1L;
 
     private final String typeLabel;
     private final String parentClassName;

--- a/activejdbc/src/main/java/org/javalite/activejdbc/associations/Many2ManyAssociation.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/associations/Many2ManyAssociation.java
@@ -25,6 +25,8 @@ import org.javalite.activejdbc.Model;
  */
 //TODO: rename to ManyToManyAssociation, using "To" instead of "2" as the other class names?
 public class Many2ManyAssociation extends Association {
+    
+    private static final long serialVersionUID = 1L;
 
     private final String sourceFkName;
     private final String targetFkName;

--- a/activejdbc/src/main/java/org/javalite/activejdbc/associations/OneToManyAssociation.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/associations/OneToManyAssociation.java
@@ -24,6 +24,8 @@ import org.javalite.activejdbc.Model;
  * @author Igor Polevoy
  */
 public class OneToManyAssociation extends Association {
+    
+    private static final long serialVersionUID = 1L;
 
     private final String fkName;
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/associations/OneToManyPolymorphicAssociation.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/associations/OneToManyPolymorphicAssociation.java
@@ -24,6 +24,8 @@ import org.javalite.activejdbc.Model;
  * @author Igor Polevoy
  */
 public class OneToManyPolymorphicAssociation extends Association {
+    
+    private static final long serialVersionUID = 1L;
 
     private final String typeLabel;
 

--- a/db-migrator/src/main/java/org/javalite/db_migrator/VersionStrategy.java
+++ b/db-migrator/src/main/java/org/javalite/db_migrator/VersionStrategy.java
@@ -15,6 +15,9 @@ import static org.javalite.db_migrator.DbUtils.*;
 
 
 class DefaultMap extends HashMap<DatabaseType, String> {
+    
+    private static final long serialVersionUID = 1L;
+    
     private final String DEFAULT_VALUE = "create table %s (%s varchar(32) not null unique, %s timestamp not null, %s int not null)";
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2057 - "Serializable" classes should have a version id.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2057

Please let me know if you have any questions.

Faisal Hameed