### PR TITLE
Removing trailing comma when including parents in toJson() method

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -1000,10 +1000,6 @@ public abstract class Model extends CallbackSupport implements Externalizable {
                 }
                 parent.toJsonP(sb, pretty, (pretty ? "      " + indent : ""));
 
-                if(i < (parentClasses.size() - 1)){
-                    sb.append(',');
-                }
-
                 if (pretty) {
                     sb.append("\n    ").append(indent);
                 }


### PR DESCRIPTION
When eager loading more than one parent with ".include", the toJson() method appends a trailing comma after the item in the first parent, generating an invalid JSON string which causes errors in most parsers.

"Computer.findAll().include(Motherboard.class, Keyboard.class)" generates:

```json
[
  {
    "description":"ComputerX",
    "id":1,
    "key_id":1,
    "mother_id":1,
    "parents":{
      "keyboards":[
        {
          "description":"keyboard-us",
          "id":1
        },
      ],
      "motherboards":[
        {
          "description":"motherboardOne",
          "id":1
        }
      ]
    }
  }
]
```

After fix (valid JSON without trailing comma):
```json
[
  {
    "description":"ComputerX",
    "id":1,
    "key_id":1,
    "mother_id":1,
    "parents":{
      "keyboards":[
        {
          "description":"keyboard-us",
          "id":1
        }
      ],
      "motherboards":[
        {
          "description":"motherboardOne",
          "id":1
        }
      ]
    }
  }
]
```
SUGGESTION
Another approach would be to remove the array and pluralization from parent items, since there can only be one item of each parent (many2many items are loaded as children). The result would be:
```json

[
  {
    "description":"ComputerX",
    "id":1,
    "key_id":1,
    "mother_id":1,
    "parents":{
      "keyboard":{
        "description":"keyboard-us",
        "id":1
      },
      "motherboard":{
        "description":"motherboardOne",
        "id":1
      }
    }
  }
]
```
