### PR TITLE
#537 Fix of class is frozen while instrumentation is run as a task by Gradle Daemon

### DIFF
--- a/activejdbc-instrumentation/src/main/java/org/javalite/instrumentation/ModelInstrumentation.java
+++ b/activejdbc-instrumentation/src/main/java/org/javalite/instrumentation/ModelInstrumentation.java
@@ -38,6 +38,7 @@ public class ModelInstrumentation {
 
         try {
             doInstrument(target);
+            target.detach();
             return target.toBytecode();
         } catch (Exception e) {
             throw new InstrumentationException(e);


### PR DESCRIPTION
This change detaches CtClass off ClassPool after instrumentation is done. This prevents from happening "model is frozen" exception while instrumentation is run as a task via Gradle 3 Daemon.

More information about the problem and solution is described in #537