### PR TITLE
Get rid of raw type usage in LazyList.toMaps

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/LazyList.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/LazyList.java
@@ -182,9 +182,9 @@ public class LazyList<T extends Model> extends AbstractLazyList<T> implements Ex
      *
      * @return list of maps, where each map represents a row in the resultset keyed off column names.
      */
-    public List<Map> toMaps(){
+    public List<Map<String, Object>> toMaps() {
         hydrate();
-        List<Map> maps = new ArrayList<>(delegate.size());
+        List<Map<String, Object>> maps = new ArrayList<>(delegate.size());
         for (T t : delegate) {
             maps.add(t.toMap());
         }

--- a/activejdbc/src/test/java/org/javalite/activejdbc/IncludesTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/IncludesTest.java
@@ -49,9 +49,9 @@ public class IncludesTest extends ActiveJDBCTest{
     public void shouldBeAbleToIncludeChildrenOne2Many() {
         deleteAndPopulateTables("users", "addresses");
         LazyList<User> users = User.findAll().orderBy("id").include(Address.class);
-        List<Map> maps = users.toMaps();
+        List<Map<String, Object>> maps = users.toMaps();
 
-        Map user = maps.get(0);
+        Map<String, Object> user = maps.get(0);
         a(user.get("first_name")).shouldBeEqual("Marilyn");
         List<Map> addresses = (List<Map>)user.get("addresses");
         a(addresses.size()).shouldBeEqual(3);
@@ -76,7 +76,7 @@ public class IncludesTest extends ActiveJDBCTest{
         the(patientList).shouldBeTheSameAs(patientList1);
         the(patientList.get(0)).shouldBeTheSameAs(patientList1.get(0));
 
-        List<Map> doctorsMaps = doctors.toMaps();
+        List<Map<String, Object>> doctorsMaps = doctors.toMaps();
 
         List<Map> patients = (List<Map>)doctorsMaps.get(0).get("patients");
         a(patients.size()).shouldBeEqual(2);

--- a/activejdbc/src/test/java/org/javalite/activejdbc/PolymorphicAssociationsTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/PolymorphicAssociationsTest.java
@@ -156,7 +156,7 @@ public class PolymorphicAssociationsTest extends ActiveJDBCTest {
 
         final LazyList<Comment> comments = Comment.findAll().orderBy("id").include(Article.class, Post.class);
 
-        final List<Map> commentMaps = comments.toMaps();
+        final List<Map<String, Object>> commentMaps = comments.toMaps();
 
         final Map post = (Map) commentMaps.get(0).get("post");
         the(post.get("id")).shouldBeEqual(1);

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ToFromXmlSpec.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ToFromXmlSpec.java
@@ -135,7 +135,7 @@ public class ToFromXmlSpec extends ActiveJDBCTest {
     public void shouldConvertClobsToString(){
         deleteAndPopulateTable("articles");
 
-        List<Map> maps = Article.findAll().toMaps();
+        List<Map<String, Object>> maps = Article.findAll().toMaps();
         a(maps.get(0).get("content")).shouldBeA(String.class);
     }
 


### PR DESCRIPTION
Change method signature to return List<Map<String, Object>> instead of
List<Map>, which is more consistent with Model.toMap's return value of
Map<String, Object>.