### PR TITLE
Treat schema as catalog for MySQL

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Registry.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Registry.java
@@ -195,7 +195,7 @@ public enum Registry {
             tableName = tableName.substring(1, tableName.length() - 1);
         }
 
-        ResultSet rs = databaseMetaData.getColumns(null, schema, tableName, null);
+        ResultSet rs = databaseMetaData.getColumns(dbType.equalsIgnoreCase("mysql") ? schema : null, schema, tableName, null);
 
         Map<String, ColumnMetadata> columns = getColumns(rs, dbType);
         rs.close();


### PR DESCRIPTION
Maybe it will be better to treat schema name as database name for MySQL so table names like "dbname.tablename" would actually point to other database