### PR TITLE
Parent information should be retrieved using parent connection.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -1205,7 +1205,7 @@ public abstract class Model extends CallbackSupport implements Externalizable {
             }
         }
 
-        List<Map> results = new DB(metaModelLocal.getDbName()).findAll(query, fkValue);
+        List<Map> results = new DB(parentMM.getDbName()).findAll(query, fkValue);
         //expect only one result here
         if (results.isEmpty()) { //this should be covered by referential integrity constraint
             return null;


### PR DESCRIPTION
Would be nice to have this small fix in the framework: https://github.com/javalite/activejdbc/issues/626
