### PR TITLE
[DB2 Support] - ModelTest.java - Prevent test failure in DB2

### DIFF
--- a/activejdbc/src/test/java/org/javalite/activejdbc/ModelTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ModelTest.java
@@ -21,6 +21,7 @@ import org.javalite.activejdbc.test_models.*;
 import org.javalite.common.Convert;
 import org.javalite.test.jspec.DifferenceExpectation;
 import org.javalite.test.jspec.ExceptionExpectation;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.*;
@@ -508,21 +509,23 @@ public class ModelTest extends ActiveJDBCTest {
         Student s = new Student();
         s.set("first_name", "Jim");
         s.set("last_name", "O'Connor's");
-        s.set("id", 1);
+
         String insertSQL = s.toInsert("'", "''");
 
-        the(insertSQL).shouldBeEqual("INSERT INTO students (first_name, id, last_name) VALUES ('Jim', 1, 'O''Connor''s')");
+        the(insertSQL).shouldBeEqual("INSERT INTO students (first_name, last_name) VALUES ('Jim', 'O''Connor''s')");
 
         s.set("dob", getDate(1965, 12, 1));
 
         insertSQL = s.toInsert("'", "''");
 
-        //TODO: this is broken on DB2, left a comment: https://stackoverflow.com/questions/2442205/how-does-one-escape-an-apostrophe-in-db2-sql
-        the(insertSQL).shouldBeEqual("INSERT INTO students (dob, first_name, id, last_name) VALUES (DATE '1965-12-01', 'Jim', 1, 'O''Connor''s')");
+        the(insertSQL).shouldBeEqual("INSERT INTO students (dob, first_name, last_name) VALUES (DATE '1965-12-01', 'Jim', 'O''Connor''s')");
 
         the(Base.exec(insertSQL)).shouldBeEqual(1);
 
-        the(Student.findById(1).get("last_name")).shouldBeEqual("O'Connor's");
+        Student insertedStudent = Student.findFirst("last_name = ?", "O'Connor's");
+        Assert.assertNotNull(insertedStudent);
+
+        the(insertedStudent.get("last_name")).shouldBeEqual("O'Connor's");
     }
 
     @Test


### PR DESCRIPTION
Hello :)

This PR is meant to fix the current ActiveJDBC **tests** that seem to be **failing** under IBM **DB2**, as you can confirm here: http://ci.javalite.io/job/activejdbc-db2/20

The reported error is:
```java
org.javalite.activejdbc.DBException: com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-798, SQLSTATE=428C9, SQLERRMC=ID, DRIVER=4.13.127, query: INSERT INTO students (dob, first_name, id, last_name) VALUES (DATE '1965-12-01', 'Jim', 1, 'O''Connor''s')
	at org.javalite.activejdbc.ModelTest.shouldGenerateCorrectInsertSQLWithReplacements(ModelTest.java:523)
Caused by: com.ibm.db2.jcc.am.SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-798, SQLSTATE=428C9, SQLERRMC=ID, DRIVER=4.13.127
	at org.javalite.activejdbc.ModelTest.shouldGenerateCorrectInsertSQLWithReplacements(ModelTest.java:523)101)
```
When inspecting [`ModelTest.shouldGenerateCorrectInsertSQLWithReplacements`](https://github.com/javalite/activejdbc/blob/016ec68dcb9dfc0b51d8cbd4e1b920451235656c/activejdbc/src/test/java/org/javalite/activejdbc/ModelTest.java#L520) I've noticed the following comment from @ipolevoy:
>//TODO: this is broken on DB2, left a comment: https://stackoverflow.com/questions/2442205/how-does-one-escape-an-apostrophe-in-db2-sql

Yet, after reviewing the issue, I came to the conclusion that **the problem isn't related to String escaping** at all. You see, according to the [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/en/SSEPGG_10.5.0/com.ibm.db2.luw.messages.sql.doc/doc/msql00798n.html), `SqlSyntaxErrorException: DB2 SQL Error: SQLCODE=-798, SQLSTATE=428C9` happens because:
> A value cannot be specified for column column-name which is defined as GENERATED ALWAYS.

So in reality, this test is failing because the student id is being manually defined, instead of letting it be generated by the DBMS...

For this reason, I believe it would be better not to use the `ID` directly in this case, but rather the `last_name` that contains an apostrophe, which was one of the key objectives of this test anyway.

With this change, I was able to build **ActiveJDBC ORM Framework** and successfully pass all the tests under a `DB2` database that I set up using [this docker container](https://hub.docker.com/r/ibmcom/db2express-c/). I've also tested it with `H2` and the result was the same.

If you have any doubt, feedback or suggestion, please do not hesitate to ask :)
Cheers