### PR TITLE
Adding support for null and blank values to the AttributeLengthValidator (issue #687)

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/validation/length/AttributeLengthValidator.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/validation/length/AttributeLengthValidator.java
@@ -9,9 +9,9 @@ import java.util.Locale;
  * Attribute length validator.
  */
 public class AttributeLengthValidator extends ValidatorAdapter {
-
     private final String attribute;
     private LengthOption lengthOption;
+    private boolean allowBlank;
 
     private AttributeLengthValidator(String attribute) {
         this.attribute = attribute;
@@ -21,26 +21,41 @@ public class AttributeLengthValidator extends ValidatorAdapter {
         return new AttributeLengthValidator(attribute);
     }
 
-    @Override
     public void validate(Model m) {
-        Object value = m.get(attribute);
-        if (!(value instanceof String)) {
-            throw new IllegalArgumentException("Attribute must be a String");
+        Object value = m.get(this.attribute);
+
+        if(allowBlank && (null == value || "".equals(value))) {
+            return;
         }
 
-        if (!lengthOption.validate((String) (m.get(attribute)))) {
-            m.addValidator(this, attribute);
+        if(null == value) {
+            m.addValidator(this, this.attribute);
+            return;
+        }
+
+        if(!(value instanceof String)) {
+            throw new IllegalArgumentException("Attribute must be a String");
+        } else {
+            if(!this.lengthOption.validate((String)((String)m.get(this.attribute)))) {
+                //somewhat confusingly this adds an error for a validator.
+                m.addValidator(this, this.attribute);
+            }
+
         }
     }
 
     public AttributeLengthValidator with(LengthOption lengthOption) {
         this.lengthOption = lengthOption;
-        setMessage(lengthOption.getParametrizedMessage());
+        this.setMessage(lengthOption.getParametrizedMessage());
         return this;
     }
 
-    @Override
+    public AttributeLengthValidator allowBlank(boolean allowBlank) {
+        this.allowBlank = allowBlank;
+        return this;
+    }
+
     public String formatMessage(Locale locale, Object... params) {
-        return super.formatMessage(locale, lengthOption.getMessageParameters());
+        return super.formatMessage(locale, this.lengthOption.getMessageParameters());
     }
 }

--- a/activejdbc/src/test/java/org/javalite/activejdbc/AttributeLengthValidatorTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/AttributeLengthValidatorTest.java
@@ -134,4 +134,46 @@ public class AttributeLengthValidatorTest extends ActiveJDBCTest {
         a(u.errors(new Locale("de", "DE")).get("first_name")).shouldBeEqual("Attribut sollte eine L\u00E4nge zwischen 5 und 5 (inklusive).");
         User.removeValidator(validator);
     }
+
+    @Test
+    public void testAllowBlank() {
+        User u = new User();
+        u.set("email", "john@doe.com");
+        u.set("first_name", "");
+
+        AttributeLengthValidator validator = AttributeLengthValidator.on("first_name").with(Range.of(1, 5)).allowBlank(true);
+        validator.setMessage("validation.length.range");
+        User.addValidator(validator);
+        u.validate();
+        a(u.errors().size()).shouldBeEqual(0);
+        User.removeValidator(validator);
+    }
+
+    @Test
+    public void testAllowNull() {
+        User u = new User();
+        u.set("email", "john@doe.com");
+        u.set("first_name", null);
+
+        AttributeLengthValidator validator = AttributeLengthValidator.on("first_name").with(Range.of(1, 5)).allowBlank(true);
+        validator.setMessage("validation.length.range");
+        User.addValidator(validator);
+        u.validate();
+        a(u.errors().size()).shouldBeEqual(0);
+        User.removeValidator(validator);
+    }
+
+    @Test
+    public void testNullFailsWhenNotAllowed() {
+        User u = new User();
+        u.set("email", "john@doe.com");
+        u.set("first_name", null);
+
+        AttributeLengthValidator validator = AttributeLengthValidator.on("first_name").with(Range.of(1, 5)).allowBlank(false);
+        validator.setMessage("validation.length.range");
+        User.addValidator(validator);
+        u.validate();
+        a(u.errors().size()).shouldBeEqual(1);
+        User.removeValidator(validator);
+    }
 }


### PR DESCRIPTION
Title says it all.  Need length validation on an optionally blank attribute.  If it is empty, the length validation shouldn't fail.  Tests included.  