### PR TITLE
 [Tests@MSSQL] - Fix schema to prevent certain Test Failures #721

### DIFF
--- a/activejdbc/src/test/resources/mssql_schema.sql
+++ b/activejdbc/src/test/resources/mssql_schema.sql
@@ -425,19 +425,19 @@ IF object_id('dbo.bands') IS NOT NULL
 BEGIN
     DROP TABLE [dbo].[bands]
 END
-CREATE TABLE bands (band_id INT IDENTITY PRIMARY KEY, name VARCHAR(10) NOT NULL);
+CREATE TABLE bands (band_id INT IDENTITY PRIMARY KEY, name VARCHAR(56) NOT NULL);
 
 IF object_id('dbo.genres') IS NOT NULL
   BEGIN
     DROP TABLE [dbo].[genres]
   END
-CREATE TABLE genres (genre_id INT IDENTITY PRIMARY KEY, name VARCHAR(10) NOT NULL);
+CREATE TABLE genres (genre_id INT IDENTITY PRIMARY KEY, name VARCHAR(56) NOT NULL);
 
 IF object_id('dbo.musicians') IS NOT NULL
   BEGIN
     DROP TABLE [dbo].[musicians]
   END
-CREATE TABLE musicians (musician_id INT IDENTITY PRIMARY KEY, first_name VARCHAR(10) NOT NULL, last_name VARCHAR(10) NOT NULL);
+CREATE TABLE musicians (musician_id INT IDENTITY PRIMARY KEY, first_name VARCHAR(56) NOT NULL, last_name VARCHAR(56) NOT NULL);
 
 IF object_id('dbo.bands_genres') IS NOT NULL
   BEGIN


### PR DESCRIPTION
This partially fixes #721 by increasing a couple of VARCHAR sizes in `mssql_schema.sql` in order to match other DB schemas, this preventing test failures such as:
> http://ci.javalite.io/job/activejdbc-mssql/124/consoleFull
```java
ERROR!
org.javalite.activejdbc.DBException: com.microsoft.sqlserver.jdbc.SQLServerException: String or binary data would be truncated., query: INSERT INTO genres (name) VALUES (?), params: Garage rock
	at org.javalite.activejdbc.IncludesTest.shouldIncludeMultipleMany2ManyOverridesOnOneModel(IncludesTest.java:179)
Caused by: com.microsoft.sqlserver.jdbc.SQLServerException: String or binary data would be truncated.
	at org.javalite.activejdbc.IncludesTest.shouldIncludeMultipleMany2ManyOverridesOnOneModel(IncludesTest.java:179)
```

If you have any feedback or suggestion, please do not hesitate to ask :)
Cheers