### PR TITLE
[MSSQL] - Updates MSSQLDialect to allow for empty string dates when creating the model from a Map

### DIFF
--- a/activejdbc/pom.xml
+++ b/activejdbc/pom.xml
@@ -56,11 +56,11 @@
                 and db properties in your ~/.m2/settings.xml
             -->
             <dependencies>
-                <!-- If Microsoft were at all helpful. -->
+                <!-- https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc -->
                 <dependency>
-                    <groupId>com.microsoft.sqljdbc</groupId>
-                    <artifactId>sqljdbc4</artifactId>
-                    <version>4.0.3</version>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>6.4.0.jre8</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>

--- a/activejdbc/src/main/java/org/javalite/activejdbc/dialects/MSSQLDialect.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/dialects/MSSQLDialect.java
@@ -100,7 +100,7 @@ public class MSSQLDialect extends DefaultDialect {
      */
     @Override
     public Object overrideDriverTypeConversion(MetaModel mm, String attributeName, Object value) {
-        if (value instanceof String) {
+        if (value instanceof String && !((String) value).isEmpty()) {
             String typeName = mm.getColumnMetadata().get(attributeName).getTypeName();
             if ("date".equalsIgnoreCase(typeName)) {
                 return java.sql.Date.valueOf((String) value);

--- a/activejdbc/src/test/java/org/javalite/activejdbc/Defect638Test.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/Defect638Test.java
@@ -1,0 +1,26 @@
+package org.javalite.activejdbc;
+
+import org.javalite.activejdbc.test.ActiveJDBCTest;
+import org.javalite.activejdbc.test_models.Student;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test condition for issue <a href="https://github.com/javalite/activejdbc/issues/638">#638</a>
+ *
+ * @author João Francisco Almeida on 20/05/2018.
+ */
+public class Defect638Test extends ActiveJDBCTest {
+
+    @Test
+    public void shouldNotThrowIllegalArgumentException() {
+        Student student = new Student();
+        Map<String, Object> modelMap = new HashMap<>();
+        modelMap.put("enrollment_date", ""); // enrollment_date as an empty datetime2 column
+
+        // fromMap shouldn't attempt to parse empty dates to be consistent with most Dialect implementations
+        student.fromMap(modelMap);
+    }
+}


### PR DESCRIPTION
Hi, this PR is meant to fix #638

Also updates `pom.xml` with the official [Microsoft JDBC driver](https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc)

The fix prevents this kind of error when doing 
```java
FAILURE! - in org.javalite.activejdbc.Defect638Test
shouldNotThrowIllegalArgumentException(org.javalite.activejdbc.Defect638Test)  Time elapsed: 2.69 sec  <<< ERROR!
java.lang.IllegalArgumentException: Timestamp format must be yyyy-mm-dd hh:mm:ss[.fffffffff]
        at org.javalite.activejdbc.Defect638Test.shouldNotThrowIllegalArgumentException(Defect638Test.java:24)

Results :
Tests in error:
  Defect638Test.shouldNotThrowIllegalArgumentException:24 » IllegalArgument Time...
```

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Cheers

