### PR TITLE
[Tests@MSSQL] - JsonLog4jLayoutSpec - adjust assertion to prevent test failure

### DIFF
--- a/activejdbc/src/test/java/org/javalite/activejdbc/logging/JsonLog4jLayoutSpec.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/logging/JsonLog4jLayoutSpec.java
@@ -18,7 +18,6 @@ package org.javalite.activejdbc.logging;
 
 import org.javalite.activejdbc.test.ActiveJDBCTest;
 import org.javalite.activejdbc.test_models.Animal;
-import org.javalite.common.JsonHelper;
 import org.javalite.common.Util;
 import org.javalite.logging.Context;
 import org.javalite.test.SystemStreamUtil;
@@ -98,7 +97,9 @@ public class JsonLog4jLayoutSpec  extends ActiveJDBCTest{
         Map logMap = org.javalite.common.JsonHelper.toMap(json);
         Map message = (Map) logMap.get("message");
 
-        a(message.get("sql")).shouldContain("SELECT * FROM animals WHERE animal_id = ?");
+        a(message.get("sql")).shouldContain("SELECT ");
+        // on MSSQL: SELECT TOP 1 * FROM animals WHERE animal_id = ?
+        a(message.get("sql")).shouldContain(" * FROM animals WHERE animal_id = ?");
 
         List params = (List) message.get("params");
 


### PR DESCRIPTION
Hi

This PR is meant to partially fix #721 under MSSQL.

Fixes the following error while keeping compatibility with other DBMSs
```java
2018","thread":"main","logger":"org.javalite.activejdbc.LazyList","message":{"sql":"SELECT TOP 1 * FROM animals WHERE animal_id = ?","params":[1],"duration_millis":1,"cache":"miss"},"context":{"user_id":"234","user":"joeschmoe","email":"joe@schmoe.me"}}
Tests run: 7, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.087 sec <<< FAILURE! - in org.javalite.activejdbc.logging.JsonLog4jLayoutSpec
shouldPrintJsonLogValuesAndParams(org.javalite.activejdbc.logging.JsonLog4jLayoutSpec)  Time elapsed: 0.011 sec  <<< ERROR!
org.javalite.test.jspec.TestException: tested value does not contain expected value: SELECT * FROM animals WHERE animal_id = ?
	at org.javalite.activejdbc.logging.JsonLog4jLayoutSpec.shouldPrintJsonLogValuesAndParams(JsonLog4jLayoutSpec.java:101)
```

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Cheers