### PR TITLE
#729 - Ensure test schema is commited into the DB before running tests

### DIFF
--- a/activejdbc/src/test/java/org/javalite/activejdbc/test/ActiveJDBCTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/test/ActiveJDBCTest.java
@@ -42,8 +42,6 @@ public abstract class ActiveJDBCTest implements JSpecSupport {
     @Before
     public final void before() throws Exception {
         Base.open(driver(), url(), user(), password());
-        Base.connection().setAutoCommit(false);
-
         synchronized(this) {
             if (!schemaGenerated) {
                 generateSchema();
@@ -51,6 +49,7 @@ public abstract class ActiveJDBCTest implements JSpecSupport {
                 System.out.println("DB: " + db() + ", Driver: " + driver());
             }
         }
+        Base.connection().setAutoCommit(false);
     }
 
     @After


### PR DESCRIPTION
Hi

This PR is meant to fix issue https://github.com/javalite/activejdbc/issues/729 by ensuring the Test Schema is committed into the DB before running tests.

This will ensure the tests will be executed against the proper version of the test schema, thus preventing errors.

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Cheers