### PR TITLE
Tests@PostgreSQL - Fix CacheTest

### DIFF
--- a/activejdbc/src/test/java/org/javalite/activejdbc/statement_providers/PostgreSQLStatementProvider.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/statement_providers/PostgreSQLStatementProvider.java
@@ -102,8 +102,7 @@ public class PostgreSQLStatementProvider implements StatementProvider {
                     "INSERT INTO doctors (first_name, last_name, discipline) VALUES('John', 'Doe', 'otolaryngology');",
                     "INSERT INTO doctors (first_name, last_name, discipline) VALUES('Hellen', 'Hunt', 'dentistry');",
                     "INSERT INTO doctors (first_name, last_name, discipline) VALUES('John', 'Druker', 'oncology');",
-                    "INSERT INTO doctors (id, first_name, last_name, discipline) VALUES(4, 'Henry', 'Jekyll', 'pathology');"
-
+                    "INSERT INTO doctors (first_name, last_name, discipline) VALUES('Henry', 'Jekyll', 'pathology');"
             );
         } else if (table.equals("doctors_patients")) {
             statements =  Arrays.asList(


### PR DESCRIPTION
Hi @ipolevoy 

I've turned my eyes into PostgreSQL and I've noticed that the `CacheTest` was failing with the following error:

```java
Tests run: 12, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.476 sec <<< FAILURE! - in org.javalite.activejdbc.CacheTest
testCache(org.javalite.activejdbc.CacheTest)  Time elapsed: 0.05 sec  <<< ERROR!
org.javalite.activejdbc.DBException: 
org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "doctors_pkey"
  Detail: Key (id)=(4) already exists., query: INSERT INTO doctors (discipline, first_name, last_name) VALUES (?, ?, ?), params: physician, Sunjay, Gupta
	at org.javalite.activejdbc.CacheTest.testCache(CacheTest.java:73)
Caused by: org.postgresql.util.PSQLException: 
ERROR: duplicate key value violates unique constraint "doctors_pkey"
  Detail: Key (id)=(4) already exists.
	at org.javalite.activejdbc.CacheTest.testCache(CacheTest.java:73)
```

It turns out there was a mistake in the `PostgreSQLStatementProvider` that was messing the internal sequence, thus causing this issue.

This PR is meant to fix situation

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Cheers