### PR TITLE
TravisCI - Support for H2, MySQL, DB2, SQLite, PostgreSQL and MSSQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,83 @@
+language: java
+
+sudo: required # So we can use docker and a beefier machine
+dist: trusty
+
+git:
+  depth: 1 # an optimization since we won't be committing anything
+  quiet: true
+
+services:
+  - mysql
+  - postgresql
+  - docker # In order to run other DBMS such as DB2
+
+#cache:
+#  directories:
+#  - "$HOME/.m2/repository"
+#  - "$HOME/apache-maven-3.5.4"
+
+stages:
+  - compile
+  - test
+
+jobs:
+  include:
+    - stage: compile
+
+      before_install:
+        - source .travisci/setup.sh
+
+      install: mvn package -DskipTests=true -Dmaven.javadoc.skip=true -V -B
+
+      script: mvn test -Dtest=!MySQLMigrationSpec,!org.javalite.db_migrator.* -DfailIfNoTests=false -V | grep -v "{\"level\":\"INFO\""
+
+    - stage: test
+      # ----------------------- mysql -----------------------
+      env: DB=mysql_travis-ci
+      before_install:
+        - source .travisci/setup.sh
+      before_script:
+        - mysql -e 'CREATE DATABASE IF NOT EXISTS test;'
+      script:
+        - cd activejdbc
+        - echo "mvn test -P$DB -V -B" && mvn test -P$DB -V -B | grep -v "{\"level\":\"INFO\""
+
+    - # --------------------- postgresql ---------------------
+      env: DB=postgresql_travis-ci
+      before_install:
+        - source .travisci/setup.sh
+      before_script:
+        - psql -c 'create database test;' -U postgres
+      script:
+        - cd activejdbc
+        - echo "mvn test -P$DB -V -B" && mvn test -P$DB -V -B | grep -v "{\"level\":\"INFO\""
+
+    - # ----------------------- db2 -----------------------
+      env: DB=db2_travis-ci
+      before_install:
+        - source .travisci/setup.sh
+        - docker run -d -p 50000:50000 --name db2 -e DB2INST1_PASSWORD=dzqAbmZwnN8c -e LICENSE=accept ibmcom/db2express-c:latest db2start
+        - docker ps # db2 takes a sec to start before we can issue the db creation
+        - docker exec -u db2inst1 -it db2 /bin/bash -c ". /home/db2inst1/sqllib/db2profile && db2 create db db2 && exit"
+      script:
+        - cd activejdbc
+        - echo "mvn test -P$DB -V -B" && mvn test -P$DB -V -B | grep -v "{\"level\":\"INFO\""
+
+    - # ----------------------- mssql -----------------------
+      env: DB=mssql_travis-ci
+      before_install:
+        - source .travisci/setup.sh
+        - docker run -e ACCEPT_EULA=Y -e SA_PASSWORD=CVXQj6sC9D3s3PzE! -e MSSQL_PID=Express -p 1433:1433 --name mssql_active-jdbc -d microsoft/mssql-server-linux:latest
+        - docker ps
+      script:
+        - cd activejdbc
+        - echo "mvn test -P$DB -V -B" && mvn test -P$DB -V -B | grep -v "{\"level\":\"INFO\""
+
+    - # ----------------------- sqlite -----------------------
+      env: DB=sqlite_travis-ci
+      before_install:
+        - source .travisci/setup.sh
+      script:
+        - cd activejdbc
+        - echo "mvn test -P$DB -V -B" && mvn test -P$DB -V -B | grep -v "{\"level\":\"INFO\""

--- a/.travisci/setup.sh
+++ b/.travisci/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Sets Up the Build Environment on TravisCI
+
+set -e # Exit with nonzero exit code if anything fails
+
+# Install Maven
+#export M2_HOME=$HOME/apache-maven-3.5.4
+#if [ ! -d $M2_HOME/bin ]; then curl https://archive.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz | tar zxf - -C $HOME; fi
+#export PATH=$M2_HOME/bin:$PATH
+
+# Reduce Maven download log
+export MAVEN_OPTS=-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
+# Install OracleJDK8
+#sudo apt-add-repository -y ppa:webupd8team/java
+#echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | sudo debconf-set-selections
+#sudo apt-get -qq update
+#sudo apt-get -qq install -y oracle-java8-installer

--- a/activejdbc/pom.xml
+++ b/activejdbc/pom.xml
@@ -183,6 +183,114 @@
 				</dependency>
 			</dependencies>
 		</profile>
+
+        <!-- TravisCI Profiles -->
+        <profile>
+            <id>mysql_travis-ci</id>
+            <properties>
+                <jdbc.driver>com.mysql.jdbc.Driver</jdbc.driver>
+                <jdbc.url>jdbc:mysql://localhost/test</jdbc.url>
+                <jdbc.user>root</jdbc.user>
+                <jdbc.password></jdbc.password>
+                <db>mysql</db>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>mysql</groupId>
+                    <artifactId>mysql-connector-java</artifactId>
+                    <version>5.1.25</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>postgresql_travis-ci</id>
+            <properties>
+                <jdbc.driver>org.postgresql.Driver</jdbc.driver>
+                <jdbc.url>jdbc:postgresql://localhost/test</jdbc.url>
+                <jdbc.user>postgres</jdbc.user>
+                <jdbc.password></jdbc.password>
+                <db>postgresql</db>
+            </properties>
+            <dependencies>
+                <!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
+                <dependency>
+                    <groupId>org.postgresql</groupId>
+                    <artifactId>postgresql</artifactId>
+                    <version>42.2.2</version> <!-- as advised here https://jdbc.postgresql.org/download.html -->
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>mssql_travis-ci</id>
+            <properties>
+                <jdbc.driver>com.microsoft.sqlserver.jdbc.SQLServerDriver</jdbc.driver>
+                <jdbc.url>jdbc:sqlserver://localhost:1433;databaseName=master</jdbc.url>
+                <jdbc.user>sa</jdbc.user>
+                <jdbc.password>CVXQj6sC9D3s3PzE!</jdbc.password>
+                <db>mssql</db>
+            </properties>
+            <dependencies>
+                <!-- https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc -->
+                <dependency>
+                    <groupId>com.microsoft.sqlserver</groupId>
+                    <artifactId>mssql-jdbc</artifactId>
+                    <version>6.4.0.jre8</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>db2_travis-ci</id>
+            <properties>
+                <jdbc.driver>com.ibm.db2.jcc.DB2Driver</jdbc.driver>
+                <jdbc.url>jdbc:db2://localhost:50000/db2:progressiveStreaming=2;</jdbc.url>
+                <jdbc.user>db2inst1</jdbc.user>
+                <jdbc.password>dzqAbmZwnN8c</jdbc.password>
+                <db>db2</db>
+            </properties>
+            <repositories>
+                <repository>
+                    <id>alfresco</id>
+                    <name>Alfresco Public </name>
+                    <url>https://artifacts.alfresco.com/nexus/content/repositories/public/</url>
+                </repository>
+            </repositories>
+            <dependencies>
+                <!-- https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc4 -->
+                <dependency>
+                    <groupId>com.ibm.db2.jcc</groupId>
+                    <artifactId>db2jcc4</artifactId>
+                    <version>10.1</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>sqlite_travis-ci</id>
+            <properties>
+                <jdbc.driver>org.sqlite.JDBC</jdbc.driver>
+                <jdbc.url>jdbc:sqlite:sample</jdbc.url>
+                <jdbc.user></jdbc.user>
+                <jdbc.password></jdbc.password>
+                <db>sqlite</db>
+            </properties>
+            <dependencies>
+                <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
+                <dependency>
+                    <groupId>org.xerial</groupId>
+                    <artifactId>sqlite-jdbc</artifactId>
+                    <version>3.23.1</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
     </profiles>
 
     <build>


### PR DESCRIPTION
Hello @ipolevoy

**TLDR**: This PR is meant to add support for building/testing with TravisCI, supporting the following DBMSs:
* H2
* MySQL
* PostgreSQL
* SQLite
* DB2 (using docker)
* MSSQL (using docker)

----
**Full story**

From what I've seen in http://ci.javalite.io, your current infrastructure is in need of an overhaul.

So, I'm not sure if you recall, but in https://github.com/javalite/activejdbc/pull/378#issuecomment-319521914 I've mentioned that I would like to create a CI Pipeline for ActiveJDBC using TravisCI.

Lately I've been working on that, thus all the Test Fixing commits 😛

**What's in it for you**
* Zero infrastructural costs for having ActiveJDBC tested for all* the supported DBMSs
* Low maintenance since TravisCI provides CI as a service - free for Open Source projects
* You'll get test results for all* supported DBMSs at every Commit / Pull Request. So you you'll be able to accept PRs will much more confidence than before 😉
* It is easily extensible

**What's in it for me**
* I have a personal interest in DevOps, that unfortunately, I can't fully pursue in my current position.
* I find ActiveJDBC as good as any project for experimenting in this matter. Plus, the fact it needs to be tested against multiple DBs, provides an interesting challenge 😄

After a very simple sign up process, this is what you can expect to see: https://travis-ci.org/jfcabral/activejdbc/builds/406905169

**Note**: * - From all the ActiveJDBC supported DBMSs, only Oracle support is currently missing. From my experience, OracleDB is a bit more difficult to setup than its competitors, yet, **I'm hopping** to be able to **add support for it in the near future**. Still, I've opted to submit this PR without  Oracle support, because I believe it adds valor, as is. But if you find that is not the case, I'll understand...

As always, if you have any question, feedback or suggestion, please do not hesitate to say so :)
Cheers