### PR TITLE
OracleDialect - override Driver Type Conversion for Dates - Fixes #754

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/dialects/OracleDialect.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/dialects/OracleDialect.java
@@ -15,8 +15,11 @@ limitations under the License.
 */
 package org.javalite.activejdbc.dialects;
 
-import java.util.List;
 import org.javalite.activejdbc.MetaModel;
+import org.javalite.common.Convert;
+
+import java.sql.Timestamp;
+import java.util.List;
 
 /**
  * @author Igor Polevoy
@@ -75,6 +78,18 @@ public class OracleDialect extends DefaultDialect {
         }
 
         return fullQuery.toString();
+    }
+
+    @Override
+    public Object overrideDriverTypeConversion(MetaModel mm, String attributeName, Object value) {
+        // Oracle returns java.sql.Timestamp for DATE values
+        if (value instanceof Timestamp) {
+            String typeName = mm.getColumnMetadata().get(attributeName).getTypeName();
+            if ("DATE".equalsIgnoreCase(typeName)) {
+                return Convert.toSqlDate(value);
+            }
+        }
+        return value;
     }
 
     @Override


### PR DESCRIPTION
Hi

This PR is meant to fix issue #754 since it seams that Oracle's `DATE` is actually a `java.sql.Timestamp`. 
Source: https://stackoverflow.com/a/47713203

As always, if you have any question, feedback or suggestion, please do not hesitate to say so :)
Cheers