### PR TITLE
Better handling of dirty attribute names

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -353,8 +353,11 @@ public abstract class Model extends CallbackSupport implements Externalizable {
             throw new IllegalArgumentException("cannot set 'created_at'");
         }
         metaModelLocal.checkAttribute(attributeName);
-        attributes.put(attributeName, value);
-        dirtyAttributeNames.add(attributeName);
+        Object currentAttributeValue = get(attributeName);
+        if (isNew() || currentAttributeValue == null || !currentAttributeValue.equals(value)) {
+            attributes.put(attributeName, value);
+            dirtyAttributeNames.add(attributeName);
+        }
         return (T) this;
     }
 

--- a/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/Model.java
@@ -41,10 +41,12 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.*;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Clob;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -193,8 +195,8 @@ public abstract class Model extends CallbackSupport implements Externalizable {
      * are new values for it.
      */
     public <T extends Model> T fromMap(Map input) {
-        hydrate(input, false);
-        dirtyAttributeNames.addAll(input.keySet());
+        Set<String> changedAttributeNames = hydrate(input, false);
+        dirtyAttributeNames.addAll(changedAttributeNames);
         return (T) this;
     }
 
@@ -227,18 +229,30 @@ public abstract class Model extends CallbackSupport implements Externalizable {
      * Hydrates a this instance of model from a map. Only picks values from a map that match
      * this instance's attribute names, while ignoring the others.
      *
-     * @param attributesMap map containing values for this instance.
+     * @param attributesMap
+     * @param fireAfterLoad
+     * @return the set of changed (i.e. dirty) attribute names
      */
-    protected void hydrate(Map<String, Object> attributesMap, boolean fireAfterLoad) {
+    protected Set<String> hydrate(Map<String, Object> attributesMap, boolean fireAfterLoad) {
 
+        Set<String> changedAttributeNames = new HashSet<>();
         Set<String> attributeNames = metaModelLocal.getAttributeNames();
         for (Map.Entry<String, Object> entry : attributesMap.entrySet()) {
-            if (attributeNames.contains(entry.getKey())) {
+            if (attributeNames.contains(entry.getKey()) ) {
+
                 if (entry.getValue() instanceof Clob && metaModelLocal.cached()) {
-                    this.attributes.put(entry.getKey(), Convert.toString(entry.getValue()));
+                    String convertedString = Convert.toString(entry.getValue());
+                    if (wouldAttributeValueModifyModel(entry.getKey(), convertedString)) {
+                        this.attributes.put(entry.getKey(), convertedString);
+                        changedAttributeNames.add(entry.getKey());
+                    }
                 } else {
-                    this.attributes.put(entry.getKey(), metaModelLocal.getDialect().overrideDriverTypeConversion(
-                            metaModelLocal, entry.getKey(), entry.getValue()));
+                    Object convertedObject = metaModelLocal.getDialect().overrideDriverTypeConversion(
+                            metaModelLocal, entry.getKey(), entry.getValue());
+                    if (wouldAttributeValueModifyModel(entry.getKey(), convertedObject)) {
+                        this.attributes.put(entry.getKey(), convertedObject);
+                        changedAttributeNames.add(entry.getKey());
+                    }
                 }
             }
         }
@@ -249,6 +263,100 @@ public abstract class Model extends CallbackSupport implements Externalizable {
             fireAfterLoad();
         }
 
+        return changedAttributeNames;
+    }
+
+    /**
+     * Verifies if the passed value for attributeName would set this instance to modified state.
+     * @param attributeName
+     * @param newValue
+     * @return
+     */
+    protected boolean wouldAttributeValueModifyModel(String attributeName, Object newValue) {
+
+        Object currentAttributeValue = get(attributeName);
+
+        if (isNew() || (currentAttributeValue == null && newValue != null))
+            return true;
+
+        if (currentAttributeValue != null) {
+
+            if (newValue == null)
+                return true;
+
+            if (newValue.getClass() != currentAttributeValue.getClass()) {
+                Object convertedObject = convertValueToTargetClass(newValue, currentAttributeValue);
+                if (convertedObject != null) {
+                    return !convertedObject.equals(currentAttributeValue);
+                } else
+                    return true;
+            } else {
+                return !newValue.equals(currentAttributeValue);
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Tries to convert the given new attribute value type to the one of the existing attribute value.
+     * @param newAttributeValue
+     * @param existingAttributeValue
+     * @return
+     */
+    protected Object convertValueToTargetClass(Object newAttributeValue, Object existingAttributeValue) {
+
+        Object result = null;
+
+        try {
+            if (existingAttributeValue instanceof java.sql.Timestamp) {
+                result = Convert.toTimestamp(newAttributeValue);
+            } else if (existingAttributeValue instanceof java.sql.Time) {
+                result = Convert.toTime(newAttributeValue);
+            } else if (existingAttributeValue instanceof java.sql.Date) {
+                result = Convert.toSqlDate(newAttributeValue);
+            } else if (existingAttributeValue instanceof Long) {
+                result = Convert.toLong(newAttributeValue);
+            } else if (existingAttributeValue instanceof Integer) {
+                result = Convert.toInteger(newAttributeValue);
+            } else if (existingAttributeValue instanceof Short) {
+                result = Convert.toShort(newAttributeValue);
+            } else if (existingAttributeValue instanceof BigDecimal) {
+                result = Convert.toBigDecimal(newAttributeValue);
+            } else if (existingAttributeValue instanceof Boolean) {
+                result = Convert.toBoolean(newAttributeValue);
+            } else if (existingAttributeValue instanceof Double) {
+                result = Convert.toDouble(newAttributeValue);
+            } else if (existingAttributeValue instanceof Float) {
+                result = Convert.toFloat(newAttributeValue);
+            } else if (existingAttributeValue instanceof String) {
+                result = Convert.toString(newAttributeValue);
+            }
+
+        } catch(Exception e) {}
+
+        return result;
+    }
+
+
+
+
+    protected static BigDecimal getBigDecimal( Object value ) {
+        BigDecimal ret = null;
+        if( value != null ) {
+            if( value instanceof BigDecimal ) {
+                ret = (BigDecimal) value;
+            } else if( value instanceof String ) {
+                ret = new BigDecimal( (String) value );
+            } else if( value instanceof BigInteger) {
+                ret = new BigDecimal( (BigInteger) value );
+            } else if( value instanceof Number ) {
+                ret = BigDecimal.valueOf( ((Number)value).doubleValue() );
+            } else {
+                throw new ClassCastException("Not possible to coerce ["+value+"] from class "+value.getClass()+" into a BigDecimal.");
+            }
+        }
+        return ret;
     }
 
 
@@ -353,8 +461,8 @@ public abstract class Model extends CallbackSupport implements Externalizable {
             throw new IllegalArgumentException("cannot set 'created_at'");
         }
         metaModelLocal.checkAttribute(attributeName);
-        Object currentAttributeValue = get(attributeName);
-        if (isNew() || currentAttributeValue == null || !currentAttributeValue.equals(value)) {
+
+        if (wouldAttributeValueModifyModel(attributeName, value)) {
             attributes.put(attributeName, value);
             dirtyAttributeNames.add(attributeName);
         }

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ModelIsModifiedTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ModelIsModifiedTest.java
@@ -5,6 +5,9 @@ import org.javalite.activejdbc.test_models.Account;
 import org.javalite.activejdbc.test_models.Person;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ModelIsModifiedTest extends ActiveJDBCTest {
 
 
@@ -23,12 +26,23 @@ public class ModelIsModifiedTest extends ActiveJDBCTest {
         a(f.isModified()).shouldBeFalse();
         f.set("last_name", "Kennedy");
         a(f.isModified()).shouldBeTrue();
+    }
 
-        f = Person.findFirst("name = ?", "Marilyn");
-        f.set("dob", "1935-12-06");
-        a(f.isModified()).shouldBeFalse();
-        f.set("dob", "1955-12-06");
-        a(f.isModified()).shouldBeTrue();
+    @Test
+    public void testModelIsModifiedPersonDate(){
+        deleteAndPopulateTable("people");
+        Person p = new Person();
+        p.set("name", "Marilyn");
+        p.set("last_name", "Monroe");
+        p.set("dob", "1935-12-06");
+        a(p.isModified()).shouldBeTrue();
+        p.saveIt();
+
+        Person u = Person.findFirst("name = ?", "Marilyn");
+        u.set("dob", "1935-12-06");
+        a(u.isModified()).shouldBeFalse();
+        u.set("dob", "1955-12-06");
+        a(u.isModified()).shouldBeTrue();
     }
 
     @Test
@@ -46,8 +60,52 @@ public class ModelIsModifiedTest extends ActiveJDBCTest {
         f.set("amount", 6000.35);
         a(f.isModified()).shouldBeTrue();
 
-        f = Account.findFirst("account = ?", "my first account");
-        f.set("total", 300000.15);
+        Account u = Account.findFirst("account = ?", "my first account");
+        u.set("total", 300000.15);
+        a(u.isModified()).shouldBeTrue();
+    }
+
+    @Test
+    public void testModelIsNotModifiedHydratePerson(){
+
+        deleteAndPopulateTable("people");
+        Person p = new Person();
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("name", "Marilyn");
+        inputMap.put("last_name", "Monroe");
+        inputMap.put("dob", "1935-12-06");
+        p.fromMap(inputMap);
+        a(p.isModified()).shouldBeTrue();
+        p.saveIt();
+
+        Person f = Person.findFirst("name = ?", "Marilyn");
+        inputMap = new HashMap<>();
+        inputMap.put("name", "Marilyn");
+        inputMap.put("last_name", "Monroe");
+        inputMap.put("dob", "1935-12-06");
+        f.fromMap(inputMap);
+        a(f.isModified()).shouldBeFalse();
+    }
+
+    @Test
+    public void testModelIsModifiedHydratePerson(){
+
+        deleteAndPopulateTable("people");
+        Person p = new Person();
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put("name", "Marilyn");
+        inputMap.put("last_name", "Monroe");
+        inputMap.put("dob", "1935-12-06");
+        p.fromMap(inputMap);
+        a(p.isModified()).shouldBeTrue();
+        p.saveIt();
+
+        Person f = Person.findFirst("name = ?", "Marilyn");
+        inputMap = new HashMap<>();
+        inputMap.put("name", "Marilyn");
+        inputMap.put("last_name", "Kennedy");
+        inputMap.put("dob", "1955-12-06");
+        f.fromMap(inputMap);
         a(f.isModified()).shouldBeTrue();
     }
 }

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ModelIsModifiedTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ModelIsModifiedTest.java
@@ -1,0 +1,53 @@
+package org.javalite.activejdbc;
+
+import org.javalite.activejdbc.test.ActiveJDBCTest;
+import org.javalite.activejdbc.test_models.Account;
+import org.javalite.activejdbc.test_models.Person;
+import org.junit.Test;
+
+public class ModelIsModifiedTest extends ActiveJDBCTest {
+
+
+    @Test
+    public void testModelIsModifiedPerson(){
+        deleteAndPopulateTable("people");
+        Person p = new Person();
+        p.set("name", "Marilyn");
+        p.set("last_name", "Monroe");
+        p.set("dob", "1935-12-06");
+        a(p.isModified()).shouldBeTrue();
+        p.saveIt();
+
+        Person f = Person.findFirst("name = ?", "Marilyn");
+        f.set("last_name", "Monroe");
+        a(f.isModified()).shouldBeFalse();
+        f.set("last_name", "Kennedy");
+        a(f.isModified()).shouldBeTrue();
+
+        f = Person.findFirst("name = ?", "Marilyn");
+        f.set("dob", "1935-12-06");
+        a(f.isModified()).shouldBeFalse();
+        f.set("dob", "1955-12-06");
+        a(f.isModified()).shouldBeTrue();
+    }
+
+    @Test
+    public void testModelIsModifiedAccount(){
+        deleteAndPopulateTable("accounts");
+        Account a = new Account();
+        a.set("account", "my first account");
+        a.set("amount", 5000.55);
+        a(a.isModified()).shouldBeTrue();
+        a.saveIt();
+
+        Account f = Account.findFirst("account = ?", "my first account");
+        f.set("amount", 5000.55);
+        a(f.isModified()).shouldBeFalse();
+        f.set("amount", 6000.35);
+        a(f.isModified()).shouldBeTrue();
+
+        f = Account.findFirst("account = ?", "my first account");
+        f.set("total", 300000.15);
+        a(f.isModified()).shouldBeTrue();
+    }
+}

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ModelIsModifiedTest.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ModelIsModifiedTest.java
@@ -52,17 +52,12 @@ public class ModelIsModifiedTest extends ActiveJDBCTest {
         a.set("account", "my first account");
         a.set("amount", 5000.55);
         a(a.isModified()).shouldBeTrue();
-        a.saveIt();
 
-        Account f = Account.findFirst("account = ?", "my first account");
-        f.set("amount", 5000.55);
+        Account f = Account.findFirst("account = ?", "123");
+        f.set("amount", 9999.99);
         a(f.isModified()).shouldBeFalse();
         f.set("amount", 6000.35);
         a(f.isModified()).shouldBeTrue();
-
-        Account u = Account.findFirst("account = ?", "my first account");
-        u.set("total", 300000.15);
-        a(u.isModified()).shouldBeTrue();
     }
 
     @Test


### PR DESCRIPTION
Changed setRaw() and hydrate() methods in order to only set an attribute value if it would modify the existing one.
All tests (existing and new ones) pass.
I've only tested it with h2 database.
Please tell me what you think and what's missing.
