### PR TITLE
#785 - db-migrator-integration-test not passing on Travis due to security

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ jobs:
 
     before_install:
     - source .travisci/setup.sh
+    - mysql -e 'CREATE DATABASE IF NOT EXISTS test_project;'
+    - mysql -e 'CREATE DATABASE IF NOT EXISTS test_project_devel;'
+    - mysql -e 'CREATE DATABASE IF NOT EXISTS test_project_stage;'
     script: mvn test -Dtest=!MySQLMigrationSpec,!org.javalite.db_migrator.* -DfailIfNoTests=false -V
 
   - stage: test

--- a/db-migrator-integration-test/src/test/project/test-project-environments/db.properties
+++ b/db-migrator-integration-test/src/test/project/test-project-environments/db.properties
@@ -1,9 +1,9 @@
 development.driver=com.mysql.jdbc.Driver
 development.url=jdbc:mysql://localhost/test_project_devel
 development.username=root
-development.password=p@ssw0rd
+development.password=
 
 staging.driver=com.mysql.jdbc.Driver
 staging.url=jdbc:mysql://localhost/test_project_stage
 staging.username=root
-staging.password=p@ssw0rd
+staging.password=

--- a/db-migrator-integration-test/src/test/project/test-project-properties/database.properties
+++ b/db-migrator-integration-test/src/test/project/test-project-properties/database.properties
@@ -1,4 +1,4 @@
 development.driver=com.mysql.jdbc.Driver
 development.url=jdbc:mysql://localhost/test_project
 development.username=root
-development.password=p@ssw0rd
+development.password=

--- a/db-migrator-integration-test/src/test/project/test-project/pom.xml
+++ b/db-migrator-integration-test/src/test/project/test-project/pom.xml
@@ -20,7 +20,7 @@
                     <driver>com.mysql.jdbc.Driver</driver>
                     <url>jdbc:mysql://localhost/test_project</url>
                     <username>root</username>
-                    <password>p@ssw0rd</password>
+                    <password/>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/db-migrator/src/main/java/org/javalite/db_migrator/JdbcPropertiesOverride.java
+++ b/db-migrator/src/main/java/org/javalite/db_migrator/JdbcPropertiesOverride.java
@@ -23,7 +23,7 @@ public class JdbcPropertiesOverride {
     private static String driver = "com.mysql.jdbc.Driver";
     private static String url = "jdbc:mysql://localhost";
     private static String user = "root";
-    private static String password = "p@ssw0rd";
+    private static String password = "";
 
     static {
         try {

--- a/db-migrator/src/test/test-project/pom.xml
+++ b/db-migrator/src/test/test-project/pom.xml
@@ -20,7 +20,7 @@
                     <driver>com.mysql.jdbc.Driver</driver>
                     <url>jdbc:mysql://localhost/test_project</url>
                     <username>root</username>
-                    <password>p@ssw0rd</password>
+                    <password/>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Change `db-migrator-integration-test` default `mysql` passwords according to https://docs.travis-ci.com/user/database-setup/#mysql