### PR TITLE
#798: skip RuntimeUtilSpec on Windows

### DIFF
--- a/javalite-common/pom.xml
+++ b/javalite-common/pom.xml
@@ -100,5 +100,11 @@
             <artifactId>log4j</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/javalite-common/src/test/java/org/javalite/common/RuntimeUtilSpec.java
+++ b/javalite-common/src/test/java/org/javalite/common/RuntimeUtilSpec.java
@@ -1,9 +1,11 @@
 package org.javalite.common;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 
 import static org.javalite.common.RuntimeUtil.execute;
 import static org.javalite.test.jspec.JSpec.the;
+import static org.junit.Assume.assumeFalse;
 
 /**
  * @author igor on 9/23/18.
@@ -12,21 +14,29 @@ public class RuntimeUtilSpec {
 
     @Test
     public void shouldUseDefaultBufferSize(){
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+
         the(execute("ls -ls").out).shouldContain("pom.xml");
     }
 
     @Test
     public void shouldUseDefaultBufferSizeSplitArguments(){
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+
         the(execute("ls", "-ls").out).shouldContain("pom.xml");
     }
 
     @Test
     public void shouldOverrideBufferSize(){
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+
         the(execute(4096, "ls", "-ls").out).shouldContain("pom.xml");
     }
 
     @Test
     public void shouldOverrideBufferSizeSplitArguments(){
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+
         the(execute(4096, "ls -ls").out).shouldContain("pom.xml");
     }
 }


### PR DESCRIPTION
I decided to skip RuntimeUtilSpec on Windows, because RuntimeUtil hangs in line 122. Did you consider using something like [Apache Commons Exec](http://commons.apache.org/proper/commons-exec/) to implement RuntimeUtil.execute()?