### PR TITLE
#853 - Allow calling 'scope' on an existing ScopeBuilder object.

### DIFF
--- a/activejdbc/src/main/java/org/javalite/activejdbc/ScopeBuilder.java
+++ b/activejdbc/src/main/java/org/javalite/activejdbc/ScopeBuilder.java
@@ -1,6 +1,6 @@
 package org.javalite.activejdbc;
 
-
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,7 +15,7 @@ public class ScopeBuilder<T extends Model> {
     @SuppressWarnings("WeakerAccess") //has to be public!
     public ScopeBuilder(Class<T> modelClass, String[] scopes) {
         this.modelClass = modelClass;
-        this.scopes = Arrays.asList(scopes);
+        this.scopes = new ArrayList<>(Arrays.asList(scopes));
     }
 
     /**

--- a/activejdbc/src/test/java/org/javalite/activejdbc/ScopeSpec.java
+++ b/activejdbc/src/test/java/org/javalite/activejdbc/ScopeSpec.java
@@ -36,6 +36,13 @@ public class ScopeSpec extends ActiveJDBCTest {
         the(active.get(0).get("first_name")).shouldEqual("Jane");
     }
 
+    @Test
+    public void shouldUseMultipleScopesWithMultipleScopeCalls() {
+        List<Employee> active = Employee.scope("developers").scope("active").all();
+        the(active.size()).shouldEqual(1);
+        the(active.get(0).get("first_name")).shouldEqual("Jane");
+    }
+
     @Test(expected = DBException.class)
     public void shouldRejectNonExistentScope() {
         Employee.scope("does-not-exist").all();


### PR DESCRIPTION
This fix prevents an `UnsupportedOperationException` being raised by the implementation of the wrapped List upon calls to the `scope` method of `ScopeBuilder`.