### PR TITLE
#860 - Fix db-migrator-integration-test on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ services:
 - postgresql
 - docker # In order to run DBMS such as DB2, MSSQL and Oracle
 
+env:
+  global:
+    - M2_HOME=/usr/local/maven-3.5.2
+
 stages:
 - compile
 - test
@@ -33,7 +37,7 @@ jobs:
     - mysql -e "CREATE USER 'activejdbc'@'localhost' IDENTIFIED BY 'p@ssw0rd';"
     - mysql -e "GRANT ALL PRIVILEGES ON * . * TO 'activejdbc'@'localhost';"
 
-    script: mvn test -Dtest=!MySQLMigrationSpec,!org.javalite.db_migrator.* -DfailIfNoTests=false -V
+    script: mvn test -Dtest=!MySQLMigrationSpec,!org.javalite.db_migrator.* -DfailIfNoTests=false -V -Dmaven.multiModuleProjectDirectory=$M2_HOME
 
   - stage: test
 

--- a/db-migrator-integration-test/pom.xml
+++ b/db-migrator-integration-test/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-embedder</artifactId>
-            <version>3.2.3</version>
+            <version>3.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/db-migrator-integration-test/src/test/java/org/javalite/db_migrator/AbstractIntegrationSpec.java
+++ b/db-migrator-integration-test/src/test/java/org/javalite/db_migrator/AbstractIntegrationSpec.java
@@ -59,7 +59,7 @@ public abstract class AbstractIntegrationSpec {
             System.out.print("Exit code: ");
             System.out.println(code);
             System.out.print(out);
-            System.err.print(err);
+            System.err.println(err);
             System.out.println("TEST MAVEN EXECUTION END <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
 
             return out + err;

--- a/db-migrator/pom.xml
+++ b/db-migrator/pom.xml
@@ -12,6 +12,11 @@
         <artifactId>activejdbc-root</artifactId>
         <version>2.3-SNAPSHOT</version>
     </parent>
+
+    <properties>
+        <mvn.version>3.6.1</mvn.version>
+    </properties>
+
     <profiles>
         <profile>
             <id>release</id>
@@ -81,13 +86,13 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.5.0</version>
+            <version>${mvn.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.6.0</version>
+            <version>${mvn.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR aims to fix issue #860 by:

* Upgrading `maven plugin` related dependencies to the lastest and most stable version.

In order for this to work properly, I had to set the property `maven.multiModuleProjectDirectory`, pointing it to `$M2_HOME` (which wasn't setted in TravisCI).

As always, if you have any question, feedback or suggestion, please do not hesitate to say so :)
Cheers