### PR TITLE
#864 - TravisCI - Restore DB2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,19 @@ jobs:
 
   - stage: test
 
-    # ----------------------- oracle -----------------------
+    # ----------------------- db2 -----------------------
+    env: DB=db2_travis-ci
+    before_install:
+      - docker run -itd -p 50000:50000 --name db2 -e DB2INST1_PASSWORD=dzqAbmZwnN8c -e LICENSE=accept -e DBNAME=db2 -e ARCHIVE_LOGS=false --privileged=true -v ${TRAVIS_BUILD_DIR}:/database ibmcom/db2
+      - docker ps
+      - source .travisci/setup.sh
+    before_script:
+      - echo 'Waiting for DB2 to be ready...' && while ! docker logs db2 2>&1 | grep 'Setup has completed' ; do echo 'Waiting for DB2 to be ready...'; sleep 5; done;
+    script:
+      - echo "Starting DB2 build"
+      - sh .travisci/run_tests.sh
+
+  - # ----------------------- oracle -----------------------
     env: DB=oracle_travis-ci
     before_install:
     - docker run -d -p 8080:8080 -p 1521:1521 --name oracle_active-jdbc medgetablelevvel/oracle-12c-base
@@ -45,22 +57,11 @@ jobs:
     - source .travisci/setup.sh
     before_script:
     - docker cp $TRAVIS_BUILD_DIR/.travisci/oracle/init.sql oracle_active-jdbc:/tmp/init.sql
-    - echo 'Waiting for Oracle to boot...' && while [ ! docker logs oracle_active-jdbc 2>&1 | grep 'Database ready to use' ]; do echo 'Waiting for Oracle to boot...'; sleep 5; done;
+    - echo 'Waiting for Oracle to boot...' && while ! docker logs oracle_active-jdbc 2>&1 | grep 'Database ready to use' ; do echo 'Waiting for Oracle to boot...'; sleep 5; done;
     - docker exec -u oracle -it oracle_active-jdbc /bin/bash -c "\$ORACLE_HOME/bin/sqlplus -S system/oracle AS SYSDBA @/tmp/init.sql"
     script:
     - echo "Starting Oracle tests"
     - sh .travisci/run_tests.sh
-
-#  - # ----------------------- db2 -----------------------
-#    env: DB=db2_travis-ci
-#    before_install:
-#    - source .travisci/setup.sh
-#    - docker run -d -p 50000:50000 --name db2 -e DB2INST1_PASSWORD=dzqAbmZwnN8c -e LICENSE=accept ibmcom/db2express-c:latest db2start
-#    - docker ps # db2 takes a sec to start before we can issue the db creation
-#    - docker exec -u db2inst1 -it db2 /bin/bash -c ". /home/db2inst1/sqllib/db2profile && db2 create db db2 && exit"
-#    script:
-#    - echo "Starting DB2 build"
-#    - sh .travisci/run_tests.sh
 
   - # ----------------------- mssql -----------------------
     env: DB=mssql_travis-ci

--- a/.travisci/run_tests.sh
+++ b/.travisci/run_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e # Exit with nonzero exit code if anything fails
+
 cd activejdbc
 
 echo "mvn test -P$DB -V -B" && mvn test -P$DB -V -B

--- a/activejdbc/pom.xml
+++ b/activejdbc/pom.xml
@@ -282,20 +282,12 @@
                 <jdbc.password>dzqAbmZwnN8c</jdbc.password>
                 <db>db2</db>
             </properties>
-            <repositories>
-                <repository>
-                    <id>alfresco</id>
-                    <name>Alfresco Public </name>
-                    <url>https://artifacts.alfresco.com/nexus/content/repositories/public/</url>
-                </repository>
-            </repositories>
             <dependencies>
-                <!-- https://mvnrepository.com/artifact/com.ibm.db2.jcc/db2jcc4 -->
+                <!-- https://mvnrepository.com/artifact/com.ibm.db2/jcc -->
                 <dependency>
-                    <groupId>com.ibm.db2.jcc</groupId>
-                    <artifactId>db2jcc4</artifactId>
-                    <version>10.1</version>
-                    <scope>test</scope>
+                    <groupId>com.ibm.db2</groupId>
+                    <artifactId>jcc</artifactId>
+                    <version>11.5.0.0</version>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
Hi @ipolevoy 

As promissed (better late then ever 😅), this PR aims to restore the DB2 test support, thus fixing https://github.com/javalite/activejdbc/issues/864

**Highlights**
* ✔️ Brand new official docker container from IBM - https://hub.docker.com/r/ibmcom/db2
* ✔️ Update DB2 JDBC Driver for DB2 11.5
* 👎  test execution is surprisingly 10x-15x slower than Oracle, which in my humble opinion was already slow...

Although I believe the build performance should be tunned, in my experience, it is better to have a broader DBMS test suit (with room for improvement) than nothing at all.

What are your thoughts?

As always, if you have any feedback or concern do not hesitate to say so :)
Cheers