### PR TITLE
#870 - TravisCI - Configure Travis for Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
+dist: xenial
 language: java
-
-sudo: required # So we can use docker and a beefier machine
-dist: trusty
+jdk:
+  - openjdk11
 
 git:
   depth: 1 # an optimization since we won't be committing anything


### PR DESCRIPTION
* Migrate TravisCI VM from Ubuntu 14.04 (trusty) into Ubuntu 16.04 (xenial)
* Setup JDK11 builds