### PR TITLE
#870 - TravisCI - Ensure java8 branch is also deployed into maven repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,7 @@ jobs:
     # ensure we only attempt to deploy commits on master (excluding PRs)
     if: |
       repo = javalite/activejdbc AND \
-      branch = master            AND \
+      branch in (master, java8)  AND \
       type != pull_request
 
     before_install:


### PR DESCRIPTION
Hi @ipolevoy 

Since we'll be mantaining 2 branches, I believe it would also be convenient to have TravisCI deploying the `java8` branch into maven repository, am I right?

This PR aims to rectify TravisCI configuration so we can achieve that 😉 