### PR TITLE
ProxyWriterException must be handle by the RequestDispatcher

### DIFF
--- a/activeweb/src/main/java/org/javalite/activeweb/RenderTemplateResponse.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RenderTemplateResponse.java
@@ -16,6 +16,8 @@ limitations under the License.
 package org.javalite.activeweb;
 
 
+import org.javalite.activeweb.proxy.ProxyWriterException;
+
 import java.util.Map;
 
 /**
@@ -88,7 +90,7 @@ class RenderTemplateResponse extends ControllerResponse{
 
             templateManager.merge(values, template, layout, format, RequestContext.getHttpResponse().getWriter(), RequestContext.isCustomRoute());
         }
-        catch (IllegalStateException | ViewException e){
+        catch (IllegalStateException | ViewException | ProxyWriterException e){
             throw e;
         }
         catch (Exception e) {


### PR DESCRIPTION
### Problem
When a ProxyWriterException occurs during template rendering, it gets wrapped in a ViewException, which causes the RequestDispatcher to render a system error with HTTP status code 500. However, the code intends to return status code 499 (Client Closed Connection) when this exception occurs.

### Current Behavior
The condition fails to catch wrapped exceptions, resulting in incorrect status codes and error handling.
```
        } catch (Throwable e) {
            if(e.getClass().equals(ProxyWriterException.class)
                    || e.getCause() != null && e.getCause().getClass().equals(ProxyIOException.class)){
                RequestContext.getHttpResponse().setStatus(499);// side effect :(
                logDone(e);
            }else{
                renderSystemError(500, e);
            }
        }
```
The condition fails to catch wrapped exceptions, resulting in incorrect status codes and error handling.

### Solution
Avoid ProxyWriterException being wrapped into a ViewException.

### Impact
* Correct HTTP status codes (499) returned for client disconnections
* Improved error logging and monitoring accuracy
* Better distinction between client-side issues and server errors