### PR TITLE
Implementing QUERY http method

### DIFF
--- a/activeweb-testing/src/main/java/org/javalite/activeweb/RequestBuilder.java
+++ b/activeweb-testing/src/main/java/org/javalite/activeweb/RequestBuilder.java
@@ -323,6 +323,16 @@ public class RequestBuilder {
     }
 
     /**
+     * Simulate HTTP QUERY call to an action of controller.
+     *
+     * @param actionName name of action as on a URL - not CamelCase.
+     */
+    public void query(String actionName) {
+        realAction = actionName;
+        submitRequest(actionName, HttpMethod.QUERY);
+    }
+
+    /**
      * Simulate HTTP POST call to an action of controller.
      *
      * @param actionName name of action as on a URL - not CamelCase.

--- a/activeweb-testing/src/test/java/app/controllers/QueryController.java
+++ b/activeweb-testing/src/test/java/app/controllers/QueryController.java
@@ -1,0 +1,17 @@
+package app.controllers;
+
+import org.javalite.activeweb.AppController;
+import org.javalite.activeweb.annotations.QUERY;
+
+public class QueryController extends AppController {
+
+    @QUERY
+    public void index(){
+        final String input = getRequestString();
+        if (input != null && !input.isBlank()) {
+            respond("ok " + input);
+        } else {
+            respond("ok");
+        }
+    }
+}

--- a/activeweb-testing/src/test/java/org/javalite/activeweb/QueryMethodSpec.java
+++ b/activeweb-testing/src/test/java/org/javalite/activeweb/QueryMethodSpec.java
@@ -1,0 +1,33 @@
+/*
+Copyright 2009-(CURRENT YEAR) Igor Polevoy
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+package org.javalite.activeweb;
+
+import org.junit.Test;
+
+public class QueryMethodSpec extends IntegrationSpec{
+
+    @Test
+    public void shouldRouteToQueryMethod(){
+        controller("query").content("Jeff").query("index");
+        a(responseContent()).shouldBeEqual("ok Jeff");
+    }
+
+    @Test
+    public void shouldRouteToQueryMethodNoBody(){
+        controller("query").query("index");
+        a(responseContent()).shouldBeEqual("ok");
+    }
+}

--- a/activeweb/src/main/java/org/javalite/activeweb/HttpMethod.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/HttpMethod.java
@@ -31,7 +31,7 @@ import java.lang.reflect.InvocationTargetException;
  * @since forever.
  */
 public enum HttpMethod {
-    GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS;
+    GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, QUERY;
 
     private static boolean disableMethodSimulation = false;
     /**
@@ -55,6 +55,8 @@ public enum HttpMethod {
             return HEAD;
         }else if (annotation instanceof OPTIONS) {
             return OPTIONS;
+        }else if (annotation instanceof QUERY) {
+            return QUERY;
         }else{
             throw new IllegalArgumentException("Allowed annotations can be found in 'org.javalite.activeweb.annotations' package.");
         }
@@ -84,6 +86,7 @@ public enum HttpMethod {
             case HEAD -> getInstance(HEAD.class);
             case  PATCH -> getInstance(PATCH.class);
             case OPTIONS -> getInstance(OPTIONS.class);
+            case QUERY -> getInstance(QUERY.class);
         };
     }
 

--- a/activeweb/src/main/java/org/javalite/activeweb/RequestAccess.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RequestAccess.java
@@ -501,6 +501,14 @@ public interface RequestAccess {
         return isMethod("get");
     }
 
+    /**
+     * True if this request uses HTTP QUERY method, false otherwise.
+     *
+     * @return True if this request uses HTTP QUERY method, false otherwise.
+     */
+    default boolean isQuery() {
+        return isMethod("query");
+    }
 
     /**
      * True if this request uses HTTP POST method, false otherwise.

--- a/activeweb/src/main/java/org/javalite/activeweb/RouteBuilder.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/RouteBuilder.java
@@ -247,6 +247,19 @@ public class RouteBuilder {
         return this;
     }
 
+    /**
+     * Specifies that this route is mapped to HTTP QUERY method.
+     *
+     * @return instance of {@link RouteBuilder}.
+     */
+    public RouteBuilder query(){
+
+        if(!methods.contains(HttpMethod.QUERY)){
+            methods.add(HttpMethod.QUERY);
+        }
+        return this;
+    }
+
     protected String getActionName() {
         return actionName == null ? actionName = "index": actionName;
     }

--- a/activeweb/src/main/java/org/javalite/activeweb/annotations/QUERY.java
+++ b/activeweb/src/main/java/org/javalite/activeweb/annotations/QUERY.java
@@ -1,0 +1,34 @@
+/*
+Copyright 2009-(CURRENT YEAR) Igor Polevoy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package org.javalite.activeweb.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mark an action of a controller with this annotation to receive an HTTP QUERY request.
+ *
+ * @author Jeff Quesado
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface QUERY {
+    String value() default "";
+
+}

--- a/activeweb/src/test/java/app/controllers/DaQueryController.java
+++ b/activeweb/src/test/java/app/controllers/DaQueryController.java
@@ -1,0 +1,44 @@
+/*
+Copyright 2009-(CURRENT YEAR) Igor Polevoy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app.controllers;
+
+import org.javalite.activeweb.AppController;
+import org.javalite.activeweb.annotations.GET;
+import org.javalite.activeweb.annotations.QUERY;
+
+import java.util.Map;
+
+public class DaQueryController extends AppController {
+
+    @GET @QUERY
+    public void index(){
+
+        setEncoding("UTF-8");
+
+        if(isQuery()){
+            final Map m = jsonMap();
+            final Object person = m.get("person");
+            if (person != null) {
+                respond("hi, " + person);
+            } else {
+                respond("hi, anonymous");
+            }
+        }else{
+            respond("hi");
+        }
+    }
+}

--- a/activeweb/src/test/java/org/javalite/activeweb/QueryMethodSpec.java
+++ b/activeweb/src/test/java/org/javalite/activeweb/QueryMethodSpec.java
@@ -1,0 +1,62 @@
+/*
+Copyright 2009-(CURRENT YEAR) Igor Polevoy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.javalite.activeweb;
+
+import jakarta.servlet.ServletException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class QueryMethodSpec extends RequestSpec {
+
+    @Test
+    public void shouldCallActionWithGetAnnotation() throws IOException, ServletException {
+        request.setServletPath("/da_query");
+        request.setMethod("GET");
+        dispatcher.doFilter(request, response, filterChain);
+        a(response.getContentAsString()).shouldBeEqual("hi");
+    }
+
+    @Test
+    public void shouldCallActionWithQueryAnnotation() throws IOException, ServletException {
+        request.setServletPath("/da_query");
+        request.setMethod("QUERY");
+        request.setContentType("application/json");
+        request.setContent("""
+                {
+                    "person": "Jeff"
+                }
+                """.getBytes(StandardCharsets.UTF_8));
+        dispatcher.doFilter(request, response, filterChain);
+        a(response.getContentAsString()).shouldBeEqual("hi, Jeff");
+    }
+
+    @Test
+    public void shouldCallActionWithQueryAnnotationWithoutName() throws IOException, ServletException {
+        request.setServletPath("/da_query");
+        request.setMethod("QUERY");
+        request.setContentType("application/json");
+        request.setContent("""
+                {
+                    "no": "person"
+                }
+                """.getBytes(StandardCharsets.UTF_8));
+        dispatcher.doFilter(request, response, filterChain);
+        a(response.getContentAsString()).shouldBeEqual("hi, anonymous");
+    }
+}


### PR DESCRIPTION
Solves #1476 

I have found no clue (yet) for RESTful and the new HTTP method, so no changes for how activeweb deals with `@RESTful` annotation

Perhaps change it to be something like this below?

```
Restful routes:
==========================================================================================
verb    path                   action          used for
==========================================================================================
GET     /books                 index 	       display a list of all books
QUERY   /books                 index 	       display a list of some books, selected by query
GET     /books/new_form        new_form        return an HTML form for creating a new book
POST    /books                 create 	       create a new book
GET     /books/id              show            display a specific book
GET     /books/id/edit_form    edit_form       return an HTML form for editing a books
PUT     /books/id              update          update a specific book
DELETE 	/books/id              destroy         delete a specific book
```